### PR TITLE
Add map() to transform the value before comparison

### DIFF
--- a/src/main/php/test/Assert.class.php
+++ b/src/main/php/test/Assert.class.php
@@ -1,7 +1,7 @@
 <?php namespace test;
 
 use lang\Type;
-use test\assert\{Assertions, Equals, Instance};
+use test\assert\{Assertable, Equals, Instance};
 
 abstract class Assert {
 
@@ -9,10 +9,10 @@ abstract class Assert {
    * Assertion DSL
    *
    * @param  mixed $value
-   * @return test.assert.Assertions
+   * @return Assertable
    */
   public static function that($value) {
-    return new Assertions($value);
+    return new Assertable($value);
   }
 
   /**
@@ -23,7 +23,7 @@ abstract class Assert {
    * @return void
    */
   public static function equals($expected, $actual) {
-    (new Assertions($actual))->is(new Equals($expected));
+    (new Assertable($actual))->is(new Equals($expected));
   }
 
   /**
@@ -34,7 +34,7 @@ abstract class Assert {
    * @return void
    */
   public static function notEquals($expected, $actual) {
-    (new Assertions($actual))->isNot(new Equals($expected));
+    (new Assertable($actual))->isNot(new Equals($expected));
   }
 
   /**
@@ -44,7 +44,7 @@ abstract class Assert {
    * @return void
    */
   public static function true($actual) {
-    (new Assertions($actual))->is(Assertions::$TRUE);
+    (new Assertable($actual))->is(Assertable::$TRUE);
   }
 
   /**
@@ -54,7 +54,7 @@ abstract class Assert {
    * @return void
    */
   public static function false($actual) {
-    (new Assertions($actual))->is(Assertions::$FALSE);
+    (new Assertable($actual))->is(Assertable::$FALSE);
   }
 
   /**
@@ -64,7 +64,7 @@ abstract class Assert {
    * @return void
    */
   public static function null($actual) {
-    (new Assertions($actual))->is(Assertions::$NULL);
+    (new Assertable($actual))->is(Assertable::$NULL);
   }
 
   /**
@@ -75,6 +75,6 @@ abstract class Assert {
    * @return void
    */
   public static function instance($expected, $actual) {
-    (new Assertions($actual))->is(new Instance($expected));
+    (new Assertable($actual))->is(new Instance($expected));
   }
 }

--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -62,6 +62,18 @@ class Assertable {
   }
 
   /**
+   * Transform the value encapsulated in this fluent interface to an
+   * array. Uses `iterator_to_array()` for traversable data structures,
+   * an array cast on values of any other type.
+   */
+  public function asArray(): self {
+    return new self($this->value instanceof Traversable
+      ? iterator_to_array($this->value)
+      : (array)$this->value
+    );
+  }
+
+  /**
    * Assert this value is equal to the given expected value
    * 
    * @param  mixed $expected

--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -4,6 +4,7 @@ use Traversable;
 use lang\Type;
 use test\AssertionFailed;
 
+/** @test test.unittest.AssertableTest */
 class Assertable {
   public static $TRUE, $FALSE, $NULL;
   private $value;

--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -4,7 +4,7 @@ use Traversable;
 use lang\Type;
 use test\AssertionFailed;
 
-class Assertions {
+class Assertable {
   public static $TRUE, $FALSE, $NULL;
   private $value;
 
@@ -39,7 +39,7 @@ class Assertions {
    * Map the value encapsulated in this fluent interface using a mapping
    * function. Works for scalars as well as arrays and any traversable
    * data structure. The given function recieves the value and returns
-   * the mapped value.
+   * the mapped value as a new `Assertable`.
    */
   public function map(callable $mapper): self {
     if (is_array($this->value)) {
@@ -61,7 +61,7 @@ class Assertions {
   }
 
   /**
-   * Test for equality
+   * Assert this value is equal to the given expected value
    * 
    * @param  mixed $expected
    * @return self
@@ -71,7 +71,7 @@ class Assertions {
   }
 
   /**
-   * Assert a given value is not equal to this value
+   * Assert this value is not equal to the given expected value
    * 
    * @param  mixed $expected
    * @return self
@@ -81,7 +81,7 @@ class Assertions {
   }
 
   /**
-   * Assert a this value is null
+   * Assert this value is null
    * 
    * @return self
    */
@@ -90,7 +90,7 @@ class Assertions {
   }
 
   /**
-   * Assert a this value is true
+   * Assert this value is true
    * 
    * @return self
    */
@@ -99,7 +99,7 @@ class Assertions {
   }
 
   /**
-   * Assert a this value is false
+   * Assert this value is false
    * 
    * @return self
    */

--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -43,34 +43,15 @@ class Assertable {
    * the mapped value as a new `Assertable`.
    */
   public function map(callable $mapper): self {
-    if (is_array($this->value)) {
+    if (is_array($this->value) || $this->value instanceof Traversable) {
       $self= new self([]);
       foreach ($this->value as $key => $element) {
         $self->value[$key]= $mapper($element);
       }
       return $self;
-    } else if ($this->value instanceof Traversable) {
-      $f= function() use($mapper) {
-        foreach ($this->value as $key => $element) {
-          yield $key => $mapper($element);
-        }
-      };
-      return new self($f());
     } else {
       return new self($mapper($this->value));
     }
-  }
-
-  /**
-   * Transform the value encapsulated in this fluent interface to an
-   * array. Uses `iterator_to_array()` for traversable data structures,
-   * an array cast on values of any other type.
-   */
-  public function asArray(): self {
-    return new self($this->value instanceof Traversable
-      ? iterator_to_array($this->value)
-      : (array)$this->value
-    );
   }
 
   /**

--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -46,11 +46,16 @@ class Assertable {
     if (is_array($this->value) || $this->value instanceof Traversable) {
       $self= new self([]);
       foreach ($this->value as $key => $element) {
-        $self->value[$key]= $mapper($element);
+        $r= $mapper($element, $key);
+        if ($r instanceof Traversable) {
+          $self->value+= iterator_to_array($r);
+        } else {
+          $self->value[$key]= $r;
+        }
       }
       return $self;
     } else {
-      return new self($mapper($this->value));
+      return new self($mapper($this->value, null));
     }
   }
 

--- a/src/main/php/test/assert/Assertions.class.php
+++ b/src/main/php/test/assert/Assertions.class.php
@@ -1,5 +1,6 @@
 <?php namespace test\assert;
 
+use Traversable;
 use lang\Type;
 use test\AssertionFailed;
 
@@ -32,6 +33,31 @@ class Assertions {
       throw new AssertionFailed($condition->describe($this->value, false));
     }
     return $this;
+  }
+
+  /**
+   * Map the value encapsulated in this fluent interface using a mapping
+   * function. Works for scalars as well as arrays and any traversable
+   * data structure. The given function recieves the value and returns
+   * the mapped value.
+   */
+  public function map(callable $mapper): self {
+    if (is_array($this->value)) {
+      $self= new self([]);
+      foreach ($this->value as $key => $element) {
+        $self->value[$key]= $mapper($element);
+      }
+      return $self;
+    } else if ($this->value instanceof Traversable) {
+      $f= function() use($mapper) {
+        foreach ($this->value as $key => $element) {
+          yield $key => $mapper($element);
+        }
+      };
+      return new self($f());
+    } else {
+      return new self($mapper($this->value));
+    }
   }
 
   /**

--- a/src/test/php/test/unittest/AssertableTest.class.php
+++ b/src/test/php/test/unittest/AssertableTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace test\unittest;
 
 use test\assert\Assertable;
-use test\{Assert, AssertionFailed, Expect, Test, Values};
+use test\{Assert, AssertionFailed, Expect, Test};
 
 class AssertableTest {
 
@@ -18,5 +18,41 @@ class AssertableTest {
   #[Test, Expect(AssertionFailed::class)]
   public function throws_assertion_failed_on_error() {
     (new Assertable($this))->isEqualTo(null);
+  }
+
+  #[Test]
+  public function map_scalar() {
+    Assert::equals(
+      new Assertable(2),
+      (new Assertable(1))->map(function($v) { return $v * 2; })
+    );
+  }
+
+  #[Test]
+  public function map_array() {
+    Assert::equals(
+      new Assertable([2, 4]),
+      (new Assertable([1, 2]))->map(function($v) { return $v * 2; })
+    );
+  }
+
+  #[Test]
+  public function map_preserves_keys() {
+    Assert::equals(
+      new Assertable(['a' => 2, 'b' => 4]),
+      (new Assertable(['a' => 1, 'b' => 2]))->map(function($v) { return $v * 2; })
+    );
+  }
+
+  #[Test]
+  public function map_traversable() {
+    $f= function() {
+      yield 1;
+      yield 2;
+    };
+    Assert::equals(
+      new Assertable([2, 4]),
+      (new Assertable($f()))->map(function($v) { return $v * 2; })->asArray()
+    );
   }
 }

--- a/src/test/php/test/unittest/AssertableTest.class.php
+++ b/src/test/php/test/unittest/AssertableTest.class.php
@@ -52,7 +52,7 @@ class AssertableTest {
     };
     Assert::equals(
       new Assertable([2, 4]),
-      (new Assertable($f()))->map(function($v) { return $v * 2; })->asArray()
+      (new Assertable($f()))->map(function($v) { return $v * 2; })
     );
   }
 }

--- a/src/test/php/test/unittest/AssertableTest.class.php
+++ b/src/test/php/test/unittest/AssertableTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace test\unittest;
 
+use lang\IllegalArgumentException;
 use test\assert\Assertable;
 use test\{Assert, AssertionFailed, Expect, Test};
 
@@ -25,6 +26,14 @@ class AssertableTest {
     Assert::equals(
       new Assertable(2),
       (new Assertable(1))->map(function($v) { return $v * 2; })
+    );
+  }
+
+  #[Test]
+  public function map_string_using_1_required_parameter_only() {
+    Assert::equals(
+      new Assertable('Test'),
+      (new Assertable(' Test '))->map('trim')
     );
   }
 
@@ -62,5 +71,10 @@ class AssertableTest {
       new Assertable([2, 4]),
       (new Assertable($f()))->map(function($v) { return $v * 2; })
     );
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function illegal_callback() {
+    (new Assertable(1))->map('not-a-function');
   }
 }

--- a/src/test/php/test/unittest/AssertableTest.class.php
+++ b/src/test/php/test/unittest/AssertableTest.class.php
@@ -45,6 +45,14 @@ class AssertableTest {
   }
 
   #[Test]
+  public function map_can_transform_keys_via_yield() {
+    Assert::equals(
+      new Assertable([1 => 'a', 2 => 'b']),
+      (new Assertable(['a' => 1, 'b' => 2]))->map(function($v, $k) { yield $v => $k; })
+    );
+  }
+
+  #[Test]
   public function map_traversable() {
     $f= function() {
       yield 1;

--- a/src/test/php/test/unittest/AssertableTest.class.php
+++ b/src/test/php/test/unittest/AssertableTest.class.php
@@ -1,0 +1,22 @@
+<?php namespace test\unittest;
+
+use test\assert\Assertable;
+use test\{Assert, AssertionFailed, Expect, Test, Values};
+
+class AssertableTest {
+
+  #[Test]
+  public function can_create() {
+    new Assertable($this);
+  }
+
+  #[Test]
+  public function returns_self_on_success() {
+    Assert::instance(Assertable::class, (new Assertable($this))->isEqualTo($this));
+  }
+
+  #[Test, Expect(AssertionFailed::class)]
+  public function throws_assertion_failed_on_error() {
+    (new Assertable($this))->isEqualTo(null);
+  }
+}

--- a/src/test/php/test/unittest/ConditionTest.class.php
+++ b/src/test/php/test/unittest/ConditionTest.class.php
@@ -12,8 +12,8 @@ class ConditionTest {
    * @param  ?string $context
    * @return ?string
    */
-  private function failures($condition, $context= null) {
-    foreach ($condition->assertions($context) as $assertion) {
+  private function failures($condition, $context) {
+    foreach ($condition->assertions(self::class) as $assertion) {
       if (!$assertion->verify()) return $assertion->requirement(false);
     }
     return null;
@@ -29,22 +29,25 @@ class ConditionTest {
 
   #[Test]
   public function success() {
-    Assert::null($this->failures(new Condition('function_exists("strlen")')));
+    Assert::that(new Condition('true'))
+      ->map(function($c) { return $this->failures($c, null); })
+      ->isNull()
+    ;
   }
 
   #[Test]
   public function failure_includes_assertion_expression() {
-    Assert::equals(
-      'failed verifying function_exists("false")',
-      $this->failures(new Condition('function_exists("false")'), self::class)
-    );
+    Assert::that(new Condition('function_exists("false")'))
+      ->map(function($c) { return $this->failures($c, null); })
+      ->isEqualTo('failed verifying function_exists("false")')
+    ;
   }
 
   #[Test]
   public function failure_can_access_context_scope() {
-    Assert::equals(
-      'failed verifying self::verify()',
-      $this->failures(new Condition('self::verify()'), self::class)
-    );
+    Assert::that(new Condition('self::verify()'))
+      ->map(function($c) { return $this->failures($c, self::class); })
+      ->isEqualTo('failed verifying self::verify()')
+    ;
   }
 }

--- a/src/test/php/test/unittest/EqualsTest.class.php
+++ b/src/test/php/test/unittest/EqualsTest.class.php
@@ -34,6 +34,11 @@ class EqualsTest {
   }
 
   #[Test]
+  public function equals_clone() {
+    Assert::true((new Equals($this))->matches(clone $this));
+  }
+
+  #[Test]
   public function array_order_is_relevant() {
     Assert::false((new Equals([1, 2, 3]))->matches([3, 2, 1]));
   }


### PR DESCRIPTION
Transforming the value before comparison can make it easier to create the value to compare against.

## Examples

Map an iterator, extract the relevant field from each record, convert to an array and compare it:

```php
$records= $db->open('select ...');
$expected= ['one', 'two'];

// Before
$actual= [];
foreach ($records as $record) {
  $actual[]= $r['name'];
}
Assert::equals($expected, $actual);

// After
Assert::that($records)->map(fn($r) => $r['name'])->isEqualTo($expected);
```

Same as above, but map by ID:

```php
$records= $db->open('select ...');
$expected= [1 => 'one', 2 => 'two'];

// Before
$actual= [];
foreach ($records as $record) {
  $actual[$r['id']]= $r['name'];
}
Assert::equals($expected, $actual);

// After
Assert::that($records)->map(fn($r) => yield $r['id'] => $r['name'])->isEqualTo($expected);
```

The `assertHashTable()` helper from [xp-forge/sequence](https://github.com/xp-forge/sequence):

```php
$s= Sequence::of($this->people)
  ->collect(Collectors::groupingBy(
    function($e) { return $e->department(); },
    Collectors::summing(function($e) { return $e->years(); })
  ))
;
$expected= ['B' => 15, 'I' => 18];

// Before
private function assertHashTable($expected, $actual) {
  Assert::instance(HashTable::class, $actual);
  $compare= [];
  foreach ($actual as $pair) {
    $compare[$pair->key]= $pair->value;
  }
  Assert::equals($expected, $compare);
}

$this->assertHashTable($expected, $s);

// After
Assert::that($s)->isInstanceOf(HashTable::class)->map(fn($p) => yield $p->key => $p->value)->isEqualTo($expected);
```


## Inspiration

*See https://github.com/xp-forge/assert#transformations - but with less magic.*