### PR TITLE
Generalize values annotation into provider handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ use test\{Assert, Test, Values};
 
 class CalculatorTest {
 
-  #[Test, Values([0, 0], [1, 1], [-1, 1])]
+  #[Test, Values([[0, 0], [1, 1], [-1, 1]])]
   public function addition($a, $b) {
     Assert::equals($a + $b, (new Calculator())->add($a, $b));
   }
@@ -88,13 +88,13 @@ use test\{Assert, Test, Values};
 
 class CalculatorTest {
 
-  private function provider(): iterable {
+  private function operands(): iterable {
     yield [0, 0];
     yield [1, 1];
     yield [-1, 1];
   }
 
-  #[Test, Values('provider')]
+  #[Test, Values(from: 'operands')]
   public function addition($a, $b) {
     Assert::equals($a + $b, (new Calculator())->add($a, $b));
   }

--- a/src/main/php/test/Provider.class.php
+++ b/src/main/php/test/Provider.class.php
@@ -1,0 +1,16 @@
+<?php namespace test;
+
+use lang\reflection\Type;
+
+interface Provider {
+
+  /**
+   * Returns values
+   *
+   * @param  Type $type
+   * @param  ?object $instance
+   * @return iterable
+   */
+  public function values($type, $instance= null);
+
+}

--- a/src/main/php/test/RunTest.class.php
+++ b/src/main/php/test/RunTest.class.php
@@ -32,12 +32,12 @@ class RunTest implements Runnable {
    * Passes arguments. Suffixes this test case's name with a comma-separted list
    * of string representations of the given arguments enclosed in square brackets.
    *
-   * @param  mixed[] $arguments
+   * @param  array|mixed $arguments
    * @return self
    */
   public function passing($arguments) {
-    $this->arguments= $arguments;
-    $this->name.= Objects::stringOf($arguments);
+    $this->arguments= is_array($arguments) ? $arguments : [$arguments];
+    $this->name.= Objects::stringOf($this->arguments);
     return $this;
   }
 

--- a/src/main/php/test/TestClass.class.php
+++ b/src/main/php/test/TestClass.class.php
@@ -28,7 +28,14 @@ class TestClass {
 
   /** @return iterable */
   public function tests() {
-    $instance= $this->type->newInstance();
+    $pass= [];
+    foreach ($this->type->annotations()->all(Provider::class) as $provider) {
+      foreach ($provider->newInstance()->values($this->type) as $arguments) {
+        $pass[]= $arguments;
+      }
+    }
+
+    $instance= $this->type->newInstance(...$pass);
 
     // Enumerate methods
     $before= $after= $cases= [];

--- a/src/main/php/test/TestClass.class.php
+++ b/src/main/php/test/TestClass.class.php
@@ -22,7 +22,7 @@ class TestClass {
   /** @return iterable */
   public function prerequisites() {
     foreach ($this->type->annotations()->all(Prerequisite::class) as $prerequisite) {
-      yield from $prerequisite->newInstance()->assertions($this->type->literal());
+      yield from $prerequisite->newInstance()->assertions($this->type);
     }
   }
 
@@ -30,20 +30,20 @@ class TestClass {
   public function tests() {
     $instance= $this->type->newInstance();
 
-    // Enumerate methods, handling BC with xp-framework/unittest annotations
+    // Enumerate methods
     $before= $after= $cases= [];
     foreach ($this->type->methods() as $method) {
       $annotations= $method->annotations();
 
-      if ($annotations->provides(Before::class) || $annotations->provides('unittest.Before')) {
+      if ($annotations->provides(Before::class)) {
         $before[]= $method;
-      } else if ($annotations->provides(After::class) || $annotations->provides('unittest.After')) {
+      } else if ($annotations->provides(After::class)) {
         $after[]= $method;
-      } else if ($annotations->provides(Test::class) || $annotations->provides('unittest.Test')) {
+      } else if ($annotations->provides(Test::class)) {
 
         // Check prerequisites, if any fail - mark test as skipped and continue with next
         foreach ($annotations->all(Prerequisite::class) as $prerequisite) {
-          foreach ($prerequisite->newInstance()->assertions($this->type->literal()) as $assertion) {
+          foreach ($prerequisite->newInstance()->assertions($this->type) as $assertion) {
             if (!$assertion->verify()) {
               $cases[]= new SkipTest($method->name(), $assertion->requirement(false));
               continue 3;
@@ -53,32 +53,21 @@ class TestClass {
 
         $case= new RunTest($method->name(), $method->closure($instance));
 
-        // Check @Expect
-        if ($expect= $annotations->type(Expect::class) ?? $annotations->type('unittest.Expect')) {
+        // Check expected exceptions
+        if ($expect= $annotations->type(Expect::class)) {
           $case->expecting(Reflection::type($expect->argument('class') ?? $expect->argument(0)));
         }
 
-        // Check @Values, which may either be:
-        //
-        // * Referencing a provider method: `Values('provider')`
-        // * Compact form for one-arg methods: `Values([1, 2, 3])`
-        // * Passing multiple arguments: `Values([['a', 'b'], ['c', 'd']])`
-        if ($values= $annotations->type(Values::class) ?? $annotations->type('unittest.Values')) {
-          $args= $values->arguments();
-          if (sizeof($args) > 1) {
-            $provider= $args;
-          } else if (is_array($args[0])) {
-            $provider= $args[0];
-          } else {
-            $provider= $this->type->method($args[0])->invoke($instance, [], $instance);
+        // For each provider, create test case variations from the values it provides
+        $variations= 0;
+        foreach ($annotations->all(Provider::class) as $provider) {
+          foreach ($provider->newInstance()->values($this->type, $instance) as $arguments) {
+            $cases[]= (clone $case)->passing($arguments);
+            $variations++;
           }
-
-          foreach ($provider as $values) {
-            $cases[]= (clone $case)->passing(is_array($values) ? $values : [$values]);
-          }
-        } else {
-          $cases[]= $case;
         }
+
+        $variations || $cases[]= $case;
       }
     }
 

--- a/src/main/php/test/Values.class.php
+++ b/src/main/php/test/Values.class.php
@@ -1,0 +1,39 @@
+<?php namespace test;
+
+use lang\reflection\Type;
+
+/**
+ * Values
+ * 
+ * - Referencing a provider method: `Values(from: 'provider')`
+ * - Compact form for one-arg methods: `Values([1, 2, 3])`
+ * - Passing multiple arguments: `Values([['a', 'b'], ['c', 'd']])`
+ */
+class Values implements Provider {
+  private $list, $from;
+
+  /**
+   * Creates a values annotation
+   *
+   * @param  iterable $list
+   * @param  ?string $from
+   */
+  public function __construct($list= [], $from= null) {
+    $this->list= $list;
+    $this->from= $from;
+  }
+
+  /**
+   * Returns values
+   *
+   * @param  Type $type
+   * @param  ?object $instance
+   * @return iterable
+   */
+  public function values($type, $instance= null) {
+    return null === $this->from
+      ? $this->list
+      : $type->method($this->from)->invoke($instance, [], $type)
+    ;
+  }
+}

--- a/src/main/php/test/verify/Condition.class.php
+++ b/src/main/php/test/verify/Condition.class.php
@@ -1,6 +1,7 @@
 <?php namespace test\verify;
 
 use Closure;
+use lang\reflection\Type;
 use test\Prerequisite;
 use test\assert\{Assertion, Verify};
 
@@ -23,15 +24,15 @@ class Condition implements Prerequisite {
   /**
    * Return assertions for a given context type
    *
-   * @param  ?string $context
+   * @param  ?Type $context
    * @return iterable
    */
   public function assertions($context) {
     if ($this->assert instanceof Closure) {
-      $result= $this->assert->bindTo(null, $context)->__invoke();
+      $result= $this->assert->bindTo(null, $context ? $context->literal() : null)->__invoke();
     } else {
       $f= eval("return function() { return {$this->assert}; };");
-      $result= $f->bindTo(null, $context)->__invoke();
+      $result= $f->bindTo(null, $context ? $context->literal() : null)->__invoke();
     }
 
     yield new Assertion($result, new Verify($this->assert));

--- a/src/main/php/test/verify/Runtime.class.php
+++ b/src/main/php/test/verify/Runtime.class.php
@@ -1,5 +1,6 @@
 <?php namespace test\verify;
 
+use lang\reflection\Type;
 use test\Prerequisite;
 use test\assert\{Assertion, Verify, Matches, RequiredVersion};
 
@@ -22,7 +23,7 @@ class Runtime implements Prerequisite {
   /**
    * Yields assertions to verify runtime OS / PHP
    *
-   * @param  ?string $context
+   * @param  ?Type $context
    * @return iterable
    */
   public function assertions($context) {

--- a/src/test/php/test/unittest/ConditionTest.class.php
+++ b/src/test/php/test/unittest/ConditionTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace test\unittest;
 
+use lang\Reflection;
+use lang\reflection\Type;
 use test\verify\Condition;
 use test\{Assert, Test, Values};
 
@@ -9,11 +11,11 @@ class ConditionTest {
    * Returns failures from verifying a condition, if any - NULL otherwise.
    *
    * @param  Condition $condition
-   * @param  ?string $context
+   * @param  ?Type $context
    * @return ?string
    */
   private function failures($condition, $context) {
-    foreach ($condition->assertions(self::class) as $assertion) {
+    foreach ($condition->assertions($context) as $assertion) {
       if (!$assertion->verify()) return $assertion->requirement(false);
     }
     return null;
@@ -46,7 +48,7 @@ class ConditionTest {
   #[Test]
   public function failure_can_access_context_scope() {
     Assert::that(new Condition('self::verify()'))
-      ->mappedBy(function($c) { return $this->failures($c, self::class); })
+      ->mappedBy(function($c) { return $this->failures($c, Reflection::type(self::class)); })
       ->isEqualTo('failed verifying self::verify()')
     ;
   }

--- a/src/test/php/test/unittest/EqualsTest.class.php
+++ b/src/test/php/test/unittest/EqualsTest.class.php
@@ -28,7 +28,7 @@ class EqualsTest {
     }];
   }
 
-  #[Test, Values('values')]
+  #[Test, Values(from: 'values')]
   public function equals_itself($value) {
     Assert::true((new Equals($value))->matches($value));
   }

--- a/src/test/php/test/unittest/FromClassTest.class.php
+++ b/src/test/php/test/unittest/FromClassTest.class.php
@@ -18,7 +18,7 @@ class FromClassTest {
     new FromClass(self::class);
   }
 
-  #[Test, Values('arguments')]
+  #[Test, Values(from: 'arguments')]
   public function type($argument) {
     Assert::equals(Reflection::type(self::class), (new FromClass($argument))->type());
   }

--- a/src/test/php/test/unittest/FromDirectoryTest.class.php
+++ b/src/test/php/test/unittest/FromDirectoryTest.class.php
@@ -24,7 +24,7 @@ class FromDirectoryTest {
     new FromDirectory('does-not-exist');
   }
 
-  #[Test, Values('arguments')]
+  #[Test, Values(from: 'arguments')]
   public function folder($argument) {
     Assert::equals(new Folder('.'), (new FromDirectory($argument))->folder());
   }


### PR DESCRIPTION
This pull request introduces a generalized *Provider* annotation, allowing for various implementations

## Value-driven tests
`#[Values]` becomes one of these implementations. *Its usage does not change, the following example from our README continues to work!*

```php
use test\{Assert, Test, Values};

class CalculatorTest {

  #[Test, Values([[0, 0], [1, 1], [-1, 1]])]
  public function addition($a, $b) {
    Assert::equals($a + $b, (new Calculator())->add($a, $b));
  }
}
```

## Example provider
Implementations must specify a `values()` method:

```php
use test\Provider;
use lang\reflection\Type;

class StartServer implements Provider {
  private $connection;

  /** Starts a new server */
  public function __construct(string $bind, ?int $port= null) {
    $port??= rand(1024, 65535);
    $this->connection= "Socket({$bind}:{$port})"; // TODO: Actual implementation ;)
  }

  /**
   * Returns values
   *
   * @param  Type $type
   * @param  ?object $instance
   * @return iterable
   */
  public function values($type, $instance= null) {
    return [$this->connection];
  }
}
```

### Used on test case
Provider values are passed as method argument, just like `#[Values]`, the previous only implementation.

```php
use test\{Assert, Test};

class ServerTest {

  #[Test, StartServer('0.0.0.0', 8080)]
  public function connect($connection) {
    Assert::equals('Socket(0.0.0.0:8080)', $connection);
  }
}
```

### Used on test group
Provider values are passed to the constructor and the connection can be used for all test cases. *Note: The provider's `values()` method is invoked with $instance= null!*

```php
use test\{Assert, Test};

#[StartServer('0.0.0.0', 8080)]
class ServerTest {

  public function __construct(private $connection) { }

  #[Test]
  public function connect() {
    Assert::equals('Socket(0.0.0.0:8080)', $this->connection);
  }
}
```