### PR TITLE
Pass [class.Name]::[pattern] to execute only test cases matching the given pattern

### DIFF
--- a/src/main/php/test/RunTest.class.php
+++ b/src/main/php/test/RunTest.class.php
@@ -16,11 +16,14 @@ class RunTest implements Runnable {
     $this->run= $run;
   }
 
+  /** @return string */
+  public function name() { return $this->name; }
+
   /**
    * Sets an expected exception type
    *
-   * @param Type $type
-   * @param ?string $message
+   * @param  Type $type
+   * @param  ?string $message
    * @return self
    */
   public function expecting(Type $type, $message= null) {

--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -71,7 +71,8 @@ class Assertable {
       }
       return $self;
     } else {
-      return new self($mapper($this->value, null));
+      $m= $mapper($this->value, null);
+      return new self($m instanceof Traversable ? iterator_to_array($m) : $m);
     }
   }
 

--- a/src/main/php/test/source/FromClass.class.php
+++ b/src/main/php/test/source/FromClass.class.php
@@ -6,11 +6,17 @@ use lang\{Reflection, XPClass};
 use test\TestClass;
 
 class FromClass {
-  private $type;
+  private $type, $selection;
 
-  /** @param string|object|XPClass|Type|ReflectionClass $arg */
-  public function __construct($arg) {
+  /**
+   * Creates a class source
+   *
+   * @param string|object|XPClass|Type|ReflectionClass $arg
+   * @param ?string $selection
+   */
+  public function __construct($arg, $selection= null) {
     $this->type= Reflection::type($arg);
+    $this->selection= $selection;
   }
 
   /** Returns the class given */
@@ -18,6 +24,6 @@ class FromClass {
 
   /** @return iterable */
   public function groups() {
-    yield new TestClass($this->type);
+    yield new TestClass($this->type, $this->selection);
   }
 }

--- a/src/main/php/test/source/FromClass.class.php
+++ b/src/main/php/test/source/FromClass.class.php
@@ -22,6 +22,9 @@ class FromClass {
   /** Returns the class given */
   public function type(): Type { return $this->type; }
 
+  /** @return ?string */
+  public function selection() { return $this->selection; }
+
   /** @return iterable */
   public function groups() {
     yield new TestClass($this->type, $this->selection);

--- a/src/main/php/xp/test/Runner.class.php
+++ b/src/main/php/xp/test/Runner.class.php
@@ -62,6 +62,8 @@ class Runner {
         $tests->add(new FromPackage(substr($args[$i], 0, -3), true));
       } else if (0 === substr_compare($args[$i], '.*', -2, 2)) {
         $tests->add(new FromPackage(substr($args[$i], 0, -2), false));
+      } else if (false !== ($p= strpos($args[$i], '::'))) {
+        $tests->add(new FromClass(substr($args[$i], 0, $p), substr($args[$i], $p + 2)));
       } else {
         $tests->add(new FromClass($args[$i]));
       }

--- a/src/test/php/test/unittest/FromClassTest.class.php
+++ b/src/test/php/test/unittest/FromClassTest.class.php
@@ -28,4 +28,10 @@ class FromClassTest {
     $fixture= new FromClass(self::class);
     Assert::equals([new TestClass(self::class)], iterator_to_array($fixture->groups()));
   }
+
+  #[Test, Values([null, 'can_create', 'can*'])]
+  public function selection($pattern) {
+    $fixture= new FromClass(self::class, $pattern);
+    Assert::equals($pattern, $fixture->selection());
+  }
 }

--- a/src/test/php/test/unittest/FromClassTest.class.php
+++ b/src/test/php/test/unittest/FromClassTest.class.php
@@ -29,9 +29,26 @@ class FromClassTest {
     Assert::equals([new TestClass(self::class)], iterator_to_array($fixture->groups()));
   }
 
-  #[Test, Values([null, 'can_create', 'can*'])]
+  #[Test]
+  public function no_selection_by_default() {
+    $fixture= new FromClass(self::class);
+    Assert::null($fixture->selection());
+  }
+
+  #[Test, Values(['can_create', 'can*'])]
   public function selection($pattern) {
     $fixture= new FromClass(self::class, $pattern);
     Assert::equals($pattern, $fixture->selection());
+  }
+
+  #[Test, Values(['can_create', 'can*'])]
+  public function selecting($pattern) {
+    $fixture= new FromClass(self::class, $pattern);
+    Assert::that($fixture)
+      ->mappedBy(function($f) { return $f->groups(); })
+      ->mappedBy(function($g) { return $g->tests(); })
+      ->mappedBy(function($t) { return $t->name(); })
+      ->isEqualTo(['can_create'])
+    ;
   }
 }

--- a/src/test/php/test/unittest/FromClassTest.class.php
+++ b/src/test/php/test/unittest/FromClassTest.class.php
@@ -24,11 +24,6 @@ class FromClassTest {
   }
 
   #[Test]
-  public function groups_yields_this() {
-    Assert::equals([new TestClass(self::class)], iterator_to_array((new FromClass(self::class))->groups()));
-  }
-
-  #[Test]
   public function no_selection_by_default() {
     Assert::null((new FromClass(self::class))->selection());
   }
@@ -45,6 +40,14 @@ class FromClassTest {
       ->mappedBy(function($g) { return $g->tests(); })
       ->mappedBy(function($t) { return $t->name(); })
       ->isEqualTo(['can_create'])
+    ;
+  }
+
+  #[Test]
+  public function groups_yields_this() {
+    Assert::that(new FromClass(self::class))
+      ->mappedBy(function($f) { return $f->groups(); })
+      ->isEqualTo([new TestClass(self::class)])
     ;
   }
 }

--- a/src/test/php/test/unittest/FromClassTest.class.php
+++ b/src/test/php/test/unittest/FromClassTest.class.php
@@ -28,19 +28,9 @@ class FromClassTest {
     Assert::null((new FromClass(self::class))->selection());
   }
 
-  #[Test, Values(['can_create', 'can*'])]
+  #[Test, Values(['can_create', 'can*', '*create'])]
   public function selection($pattern) {
     Assert::equals($pattern, (new FromClass(self::class, $pattern))->selection());
-  }
-
-  #[Test, Values(['can_create', 'can*'])]
-  public function selecting($pattern) {
-    Assert::that(new FromClass(self::class, $pattern))
-      ->mappedBy(function($f) { return $f->groups(); })
-      ->mappedBy(function($g) { return $g->tests(); })
-      ->mappedBy(function($t) { return $t->name(); })
-      ->isEqualTo(['can_create'])
-    ;
   }
 
   #[Test]
@@ -48,6 +38,16 @@ class FromClassTest {
     Assert::that(new FromClass(self::class))
       ->mappedBy(function($f) { return $f->groups(); })
       ->isEqualTo([new TestClass(self::class)])
+    ;
+  }
+
+  #[Test, Values(['can_create', 'can*', '*create'])]
+  public function selecting($pattern) {
+    Assert::that(new FromClass(self::class, $pattern))
+      ->mappedBy(function($f) { return $f->groups(); })
+      ->mappedBy(function($g) { return $g->tests(); })
+      ->mappedBy(function($t) { return $t->name(); })
+      ->isEqualTo(['can_create'])
     ;
   }
 }

--- a/src/test/php/test/unittest/FromClassTest.class.php
+++ b/src/test/php/test/unittest/FromClassTest.class.php
@@ -25,26 +25,22 @@ class FromClassTest {
 
   #[Test]
   public function groups_yields_this() {
-    $fixture= new FromClass(self::class);
-    Assert::equals([new TestClass(self::class)], iterator_to_array($fixture->groups()));
+    Assert::equals([new TestClass(self::class)], iterator_to_array((new FromClass(self::class))->groups()));
   }
 
   #[Test]
   public function no_selection_by_default() {
-    $fixture= new FromClass(self::class);
-    Assert::null($fixture->selection());
+    Assert::null((new FromClass(self::class))->selection());
   }
 
   #[Test, Values(['can_create', 'can*'])]
   public function selection($pattern) {
-    $fixture= new FromClass(self::class, $pattern);
-    Assert::equals($pattern, $fixture->selection());
+    Assert::equals($pattern, (new FromClass(self::class, $pattern))->selection());
   }
 
   #[Test, Values(['can_create', 'can*'])]
   public function selecting($pattern) {
-    $fixture= new FromClass(self::class, $pattern);
-    Assert::that($fixture)
+    Assert::that(new FromClass(self::class, $pattern))
       ->mappedBy(function($f) { return $f->groups(); })
       ->mappedBy(function($g) { return $g->tests(); })
       ->mappedBy(function($t) { return $t->name(); })


### PR DESCRIPTION
Add a pattern to the class name, separated by `::`. The pattern may contain `*` or `?` as well as groups of characters inside square brackets, see https://www.php.net/fnmatch

Only run addition tests:
```bash
$ xp test CalculatorTest::addition
> [PASS] CalculatorTest
  ✓ addition[1, 2]
  ✓ addition[0, 3]

Test cases:  2 succeeded, 0 skipped, 0 failed
Memory used: 1630.90 kB (1685.02 kB peak)
Time taken:  0.001 seconds
```

Run all tests whose names start with "rand":
```bash
$ xp test CalculatorTest::rand*
> [PASS] CalculatorTest
  ⦾ random_floating_point // Skip: failed verifying self::randomExtensionAvailable()

Test cases:  0 succeeded, 1 skipped, 0 failed
Memory used: 1575.02 kB (1629.14 kB peak)
Time taken:  0.000 seconds
```