### PR TITLE
Implement passing command line arguments via `#[Args]` annotation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0",
-    "xp-framework/reflection": "^2.8",
+    "xp-framework/reflection": "^2.9",
     "php" : ">=7.0.0"
   },
   "bin": ["bin/xp.xp-framework.test"],

--- a/src/main/php/test/Args.class.php
+++ b/src/main/php/test/Args.class.php
@@ -1,7 +1,15 @@
 <?php namespace test;
 
+use lang\IllegalArgumentException;
+
 /**
  * Selects command line arguments
+ *
+ * - Select all arguments: `Args`
+ * - Select by position: `Args(0)`
+ * - Select named *--dsn=...*: `Args('dsn')`
+ *
+ * @test  test.unittest.ArgsTest
  */
 class Args implements Provider {
   private $select;
@@ -22,8 +30,32 @@ class Args implements Provider {
    * @return iterable
    */
   public function values($context) {
+
+    // Select all arguments
+    if (empty($this->select)) {
+      yield from $context->arguments;
+      return;
+    }
+
+    // Select specific arguments, either by position or by --name=...
     foreach ($this->select as $select) {
-      yield $context->arguments[$select];
+      if (is_int($select)) {
+        if (isset($context->arguments[$select])) {
+          yield $context->arguments[$select];
+          continue;
+        }
+        throw new IllegalArgumentException("Missing argument #{$select}");
+      } else {
+        $prefix= "--{$select}=";
+        $l= strlen($prefix);
+        foreach ($context->arguments as $argument) {
+          if (0 === strncmp($argument, $prefix, $l)) {
+            yield substr($argument, $l);
+            continue 2;
+          }
+        }
+        throw new IllegalArgumentException("Missing argument --{$select}");
+      }
     }
   }
 }

--- a/src/main/php/test/Args.class.php
+++ b/src/main/php/test/Args.class.php
@@ -1,0 +1,29 @@
+<?php namespace test;
+
+/**
+ * Selects command line arguments
+ */
+class Args implements Provider {
+  private $select;
+
+  /**
+   * Creates an args annotation
+   *
+   * @param  mixed... $select
+   */
+  public function __construct(...$select) {
+    $this->select= $select;
+  }
+
+  /**
+   * Returns values
+   *
+   * @param  Context $context
+   * @return iterable
+   */
+  public function values($context) {
+    foreach ($this->select as $select) {
+      yield $context->arguments[$select];
+    }
+  }
+}

--- a/src/main/php/test/Context.class.php
+++ b/src/main/php/test/Context.class.php
@@ -1,0 +1,13 @@
+<?php namespace test;
+
+use lang\reflection\Type;
+
+class Context {
+  public $type, $arguments;
+  public $instance= null;
+
+  public function __construct(Type $type, array $arguments= []) {
+    $this->type= $type;
+    $this->arguments= $arguments;
+  }
+}

--- a/src/main/php/test/Group.class.php
+++ b/src/main/php/test/Group.class.php
@@ -20,9 +20,10 @@ abstract class Group {
   /**
    * Yields tests in this group
    *
+   * @param  array<string> $arguments
    * @return iterable
    * @throws GroupFailed
    */
-  public abstract function tests();
+  public abstract function tests($arguments= []);
 
 }

--- a/src/main/php/test/Provider.class.php
+++ b/src/main/php/test/Provider.class.php
@@ -1,16 +1,13 @@
 <?php namespace test;
 
-use lang\reflection\Type;
-
 interface Provider {
 
   /**
    * Returns values
    *
-   * @param  Type $type
-   * @param  ?object $instance
+   * @param  Context $context
    * @return iterable
    */
-  public function values($type, $instance= null);
+  public function values($context);
 
 }

--- a/src/main/php/test/TestClass.class.php
+++ b/src/main/php/test/TestClass.class.php
@@ -1,7 +1,7 @@
 <?php namespace test;
 
-use lang\reflection\{Type, InvocationFailed};
-use lang\{Reflection, XPClass, Throwable};
+use lang\reflection\{CannotInstantiate, InvocationFailed, Type};
+use lang\{Reflection, Throwable, XPClass};
 use test\verify\Verification;
 
 class TestClass extends Group {
@@ -41,6 +41,10 @@ class TestClass extends Group {
       $context->instance= $this->type->newInstance(...$pass);
     } catch (InvocationFailed $e) {
       throw new GroupFailed($e->target()->compoundName(), $e->getCause());
+    } catch (CannotInstantiate $e) {
+      throw new GroupFailed($e->type()->name(), $e->getCause());
+    } catch (Throwable $e) {
+      throw new GroupFailed($this->type->name(), $e);
     }
 
     // Enumerate methods

--- a/src/main/php/test/TestClass.class.php
+++ b/src/main/php/test/TestClass.class.php
@@ -44,7 +44,7 @@ class TestClass extends Group {
     } catch (CannotInstantiate $e) {
       throw new GroupFailed($e->type()->name(), $e->getCause());
     } catch (Throwable $e) {
-      throw new GroupFailed($this->type->name(), $e);
+      throw new GroupFailed('providers', $e);
     }
 
     // Enumerate methods

--- a/src/main/php/test/Values.class.php
+++ b/src/main/php/test/Values.class.php
@@ -26,14 +26,13 @@ class Values implements Provider {
   /**
    * Returns values
    *
-   * @param  Type $type
-   * @param  ?object $instance
+   * @param  Context $context
    * @return iterable
    */
-  public function values($type, $instance= null) {
+  public function values($context) {
     return null === $this->from
       ? $this->list
-      : $type->method($this->from)->invoke($instance, [], $type)
+      : $context->type->method($this->from)->invoke($context->instance, [], $context->type)
     ;
   }
 }

--- a/src/main/php/test/verify/Condition.class.php
+++ b/src/main/php/test/verify/Condition.class.php
@@ -1,7 +1,6 @@
 <?php namespace test\verify;
 
 use Closure;
-use lang\reflection\Type;
 use test\assert\{Assertion, Verify};
 
 /**
@@ -23,7 +22,7 @@ class Condition implements Verification {
   /**
    * Return assertions for a given context type
    *
-   * @param  ?Type $context
+   * @param  Context $context
    * @return iterable
    */
   public function assertions($context) {
@@ -33,7 +32,7 @@ class Condition implements Verification {
     ;
 
     yield new Assertion(
-      $assertion->bindTo(null, $context ? $context->literal() : null)->__invoke(),
+      $assertion->bindTo(null, $context->type->literal())->__invoke(),
       new Verify($this->assert)
     );
   }

--- a/src/main/php/test/verify/Runtime.class.php
+++ b/src/main/php/test/verify/Runtime.class.php
@@ -1,6 +1,5 @@
 <?php namespace test\verify;
 
-use lang\reflection\Type;
 use test\assert\{Assertion, Verify, Matches, RequiredVersion};
 
 class Runtime implements Verification {
@@ -22,7 +21,7 @@ class Runtime implements Verification {
   /**
    * Yields assertions to verify runtime OS / PHP
    *
-   * @param  ?Type $context
+   * @param  Context $context
    * @return iterable
    */
   public function assertions($context) {

--- a/src/main/php/test/verify/Verification.class.php
+++ b/src/main/php/test/verify/Verification.class.php
@@ -3,9 +3,9 @@
 interface Verification {
 
   /**
-   * Return assertions for a given context type
+   * Return assertions for a given context
    *
-   * @param  ?string $context
+   * @param  Context $context
    * @return iterable
    */
   public function assertions($context);

--- a/src/main/php/xp/test/Runner.class.php
+++ b/src/main/php/xp/test/Runner.class.php
@@ -60,8 +60,12 @@ class Runner {
     $overall= new Timer();
     $tests= new Tests();
     $metrics= new Metrics();
+    $pass= [];
     for ($i= 0, $s= sizeof($args); $i < $s; $i++) {
-      if (is_dir($args[$i])) {
+      if ('--' === $args[$i]) {
+        $pass= array_slice($args, $i + 1);
+        break;
+      } else if (is_dir($args[$i])) {
         $tests->add(new FromDirectory($args[$i]));
       } else if (is_file($args[$i])) {
         $tests->add(new FromFile($args[$i]));
@@ -100,7 +104,7 @@ class Runner {
       $grouped= [];
       $before= $metrics->count['failure'];
       try {
-        foreach ($group->tests() as $test) {
+        foreach ($group->tests($pass) as $test) {
           Console::writef("\r%s", $progress[$i++] ?? $progress[$i= 0]);
 
           $timer->start();

--- a/src/main/php/xp/test/Runner.class.php
+++ b/src/main/php/xp/test/Runner.class.php
@@ -65,6 +65,9 @@ class Runner {
       if ('--' === $args[$i]) {
         $pass= array_slice($args, $i + 1);
         break;
+      } else if (0 === strncmp($args[$i], '--', 2)) {
+        $pass= array_slice($args, $i);
+        break;
       } else if (is_dir($args[$i])) {
         $tests->add(new FromDirectory($args[$i]));
       } else if (is_file($args[$i])) {

--- a/src/test/php/test/unittest/ArgsTest.class.php
+++ b/src/test/php/test/unittest/ArgsTest.class.php
@@ -1,0 +1,46 @@
+<?php namespace test\unittest;
+
+use lang\{Reflection, IllegalArgumentException};
+use test\{Args, Assert, Context, Expect, Test, Values};
+
+class ArgsTest {
+
+  #[Test]
+  public function can_create() {
+    new Args();
+  }
+
+  #[Test, Values([[[]], [['test']], [['one', 'two']]])]
+  public function select_all($arguments) {
+    Assert::equals(
+      $arguments,
+      iterator_to_array((new Args())->values(new Context(Reflection::type(self::class), $arguments)))
+    );
+  }
+
+  #[Test, Values([[['test']], [['one', 'two']]])]
+  public function select_first($arguments) {
+    Assert::equals(
+      [$arguments[0]],
+      iterator_to_array((new Args(0))->values(new Context(Reflection::type(self::class), $arguments)))
+    );
+  }
+
+  #[Test, Values([[['--dsn=test']], [['positional', '--dsn=test']]])]
+  public function select_named($arguments) {
+    Assert::equals(
+      ['test'],
+      iterator_to_array((new Args('dsn'))->values(new Context(Reflection::type(self::class), $arguments)))
+    );
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function missing_positional_argument() {
+    iterator_to_array((new Args(0))->values(new Context(Reflection::type(self::class), [])));
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function missing_named_argument() {
+    iterator_to_array((new Args('dsn'))->values(new Context(Reflection::type(self::class), [])));
+  }
+}

--- a/src/test/php/test/unittest/ConditionTest.class.php
+++ b/src/test/php/test/unittest/ConditionTest.class.php
@@ -1,9 +1,8 @@
 <?php namespace test\unittest;
 
 use lang\Reflection;
-use lang\reflection\Type;
 use test\verify\Condition;
-use test\{Assert, Test, Values};
+use test\{Assert, Context, Test, Values};
 
 class ConditionTest {
 
@@ -11,11 +10,10 @@ class ConditionTest {
    * Returns failures from verifying a condition, if any - NULL otherwise.
    *
    * @param  Condition $condition
-   * @param  ?Type $context
    * @return ?string
    */
-  private function failures($condition, $context) {
-    foreach ($condition->assertions($context) as $assertion) {
+  private function failures($condition) {
+    foreach ($condition->assertions(new Context(Reflection::type(self::class))) as $assertion) {
       if (!$assertion->verify()) return $assertion->requirement(false);
     }
     return null;
@@ -32,7 +30,7 @@ class ConditionTest {
   #[Test]
   public function success() {
     Assert::that(new Condition('true'))
-      ->mappedBy(function($c) { return $this->failures($c, null); })
+      ->mappedBy([$this, 'failures'])
       ->isNull()
     ;
   }
@@ -40,7 +38,7 @@ class ConditionTest {
   #[Test]
   public function failure_includes_assertion_expression() {
     Assert::that(new Condition('function_exists("false")'))
-      ->mappedBy(function($c) { return $this->failures($c, null); })
+      ->mappedBy([$this, 'failures'])
       ->isEqualTo('Failed verifying function_exists("false")')
     ;
   }
@@ -48,7 +46,7 @@ class ConditionTest {
   #[Test]
   public function failure_can_access_context_scope() {
     Assert::that(new Condition('self::verify()'))
-      ->mappedBy(function($c) { return $this->failures($c, Reflection::type(self::class)); })
+      ->mappedBy([$this, 'failures'])
       ->isEqualTo('Failed verifying self::verify()')
     ;
   }


### PR DESCRIPTION
## Declaration

```php
use test\Args;
use com\mongodb\MongoConnection;

#[Args]
class IntegrationTest {
  private $conn;

  public function __construct(string $dsn) {
    $this->conn= new MongoConnection($dsn);
  }

  // ...shortened for brevity
}
```

## Usage

```bash
$ xp test IntegrationTest -- mongodb://localhost
# ...
```

## Selecting arguments

- Select all arguments: `Args`
- Select by position: `Args(0)`
- Select named *--dsn=...*: `Args('dsn')`

**Important**: Missing arguments raise an exception:

![image](https://user-images.githubusercontent.com/696742/215355198-bed93e9f-62b4-489b-be53-f5d44eca7a24.png)


