### PR TITLE
Move classes used during execution into dedicated package

### DIFF
--- a/src/main/php/test/Args.class.php
+++ b/src/main/php/test/Args.class.php
@@ -31,7 +31,6 @@ class Args implements Provider {
    * @return iterable
    */
   public function values($context) {
-    var_dump($context);
 
     // Select all arguments
     if (empty($this->select)) {

--- a/src/main/php/test/Args.class.php
+++ b/src/main/php/test/Args.class.php
@@ -1,6 +1,7 @@
 <?php namespace test;
 
 use lang\IllegalArgumentException;
+use test\execution\Context;
 
 /**
  * Selects command line arguments
@@ -30,6 +31,7 @@ class Args implements Provider {
    * @return iterable
    */
   public function values($context) {
+    var_dump($context);
 
     // Select all arguments
     if (empty($this->select)) {

--- a/src/main/php/test/Provider.class.php
+++ b/src/main/php/test/Provider.class.php
@@ -1,5 +1,7 @@
 <?php namespace test;
 
+use test\execution\Context;
+
 interface Provider {
 
   /**

--- a/src/main/php/test/Values.class.php
+++ b/src/main/php/test/Values.class.php
@@ -1,6 +1,7 @@
 <?php namespace test;
 
 use lang\reflection\Type;
+use test\execution\Context;
 
 /**
  * Values

--- a/src/main/php/test/execution/Context.class.php
+++ b/src/main/php/test/execution/Context.class.php
@@ -1,4 +1,4 @@
-<?php namespace test;
+<?php namespace test\execution;
 
 use lang\reflection\Type;
 

--- a/src/main/php/test/execution/Group.class.php
+++ b/src/main/php/test/execution/Group.class.php
@@ -1,4 +1,4 @@
-<?php namespace test;
+<?php namespace test\execution;
 
 abstract class Group {
 

--- a/src/main/php/test/execution/GroupFailed.class.php
+++ b/src/main/php/test/execution/GroupFailed.class.php
@@ -1,4 +1,4 @@
-<?php namespace test;
+<?php namespace test\execution;
 
 use lang\{Throwable, XPException};
 

--- a/src/main/php/test/execution/Metrics.class.php
+++ b/src/main/php/test/execution/Metrics.class.php
@@ -1,4 +1,6 @@
-<?php namespace test;
+<?php namespace test\execution;
+
+use test\Outcome;
 
 class Metrics {
   public $count= ['success' => 0, 'failure' => 0, 'skipped' => 0];

--- a/src/main/php/test/execution/RunTest.class.php
+++ b/src/main/php/test/execution/RunTest.class.php
@@ -1,8 +1,9 @@
-<?php namespace test;
+<?php namespace test\execution;
 
 use Throwable as Any;
 use lang\reflection\Type;
 use lang\{Throwable, Runnable};
+use test\Outcome;
 use test\outcome\{Succeeded, Skipped, Failed};
 use util\Objects;
 

--- a/src/main/php/test/execution/SkipTest.class.php
+++ b/src/main/php/test/execution/SkipTest.class.php
@@ -1,4 +1,4 @@
-<?php namespace test;
+<?php namespace test\execution;
 
 use lang\Runnable;
 use test\outcome\Skipped;

--- a/src/main/php/test/execution/TestClass.class.php
+++ b/src/main/php/test/execution/TestClass.class.php
@@ -1,8 +1,9 @@
-<?php namespace test;
+<?php namespace test\execution;
 
 use lang\reflection\{CannotInstantiate, InvocationFailed, Type};
 use lang\{Reflection, Throwable, XPClass};
 use test\verify\Verification;
+use test\{After, Before, Expect, Ignore, Provider, Test};
 
 class TestClass extends Group {
   private $type, $selection;

--- a/src/main/php/test/execution/Tests.class.php
+++ b/src/main/php/test/execution/Tests.class.php
@@ -1,4 +1,4 @@
-<?php namespace test;
+<?php namespace test\execution;
 
 class Tests {
   private $tests;

--- a/src/main/php/test/source/FromClass.class.php
+++ b/src/main/php/test/source/FromClass.class.php
@@ -3,7 +3,7 @@
 use ReflectionClass;
 use lang\reflection\Type;
 use lang\{Reflection, XPClass};
-use test\TestClass;
+use test\execution\TestClass;
 
 class FromClass {
   private $type, $selection;

--- a/src/main/php/test/source/FromDirectory.class.php
+++ b/src/main/php/test/source/FromDirectory.class.php
@@ -2,7 +2,7 @@
 
 use io\{Folder, Path};
 use lang\{ClassLoader, FileSystemClassLoader, IllegalArgumentException};
-use test\TestClass;
+use test\execution\TestClass;
 
 class FromDirectory {
   private $folder;

--- a/src/main/php/test/source/FromFile.class.php
+++ b/src/main/php/test/source/FromFile.class.php
@@ -3,7 +3,7 @@
 use io\{File, Path};
 use lang\reflection\Type;
 use lang\{ClassLoader, Reflection, IllegalArgumentException};
-use test\TestClass;
+use test\execution\TestClass;
 
 class FromFile {
   private $type;

--- a/src/main/php/test/source/FromPackage.class.php
+++ b/src/main/php/test/source/FromPackage.class.php
@@ -1,7 +1,7 @@
 <?php namespace test\source;
 
 use lang\reflection\Package;
-use test\TestClass;
+use test\execution\TestClass;
 
 class FromPackage {
   private $package, $recursive;

--- a/src/main/php/xp/test/Runner.class.php
+++ b/src/main/php/xp/test/Runner.class.php
@@ -1,8 +1,8 @@
 <?php namespace xp\test;
 
 use lang\Runtime;
+use test\execution\{GroupFailed, Metrics, Tests};
 use test\source\{FromClass, FromDirectory, FromFile, FromPackage};
-use test\{Tests, Metrics, GroupFailed};
 use util\Objects;
 use util\cmd\Console;
 use util\profiling\Timer;

--- a/src/test/php/test/unittest/ArgsTest.class.php
+++ b/src/test/php/test/unittest/ArgsTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace test\unittest;
 
 use lang\{Reflection, IllegalArgumentException};
-use test\{Args, Assert, Context, Expect, Test, Values};
+use test\execution\Context;
+use test\{Args, Assert, Expect, Test, Values};
 
 class ArgsTest {
 

--- a/src/test/php/test/unittest/ConditionTest.class.php
+++ b/src/test/php/test/unittest/ConditionTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace test\unittest;
 
 use lang\Reflection;
+use test\execution\Context;
 use test\verify\Condition;
-use test\{Assert, Context, Test, Values};
+use test\{Assert, Test, Values};
 
 class ConditionTest {
 

--- a/src/test/php/test/unittest/FromClassTest.class.php
+++ b/src/test/php/test/unittest/FromClassTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace test\unittest;
 
 use lang\{XPClass, Reflection};
+use test\execution\TestClass;
 use test\source\FromClass;
-use test\{Assert, Test, Values, TestClass};
+use test\{Assert, Test, Values};
 
 class FromClassTest {
 


### PR DESCRIPTION
Package overview after:

```bash
$ xp reflect test
@FileSystemCL<./src/main/php>
@FileSystemCL<./src/test/php>
package test {
  package test.assert
  package test.execution
  package test.outcome
  package test.source
  package test.verify
  package test.unittest

  public interface test.Prerequisite
  public interface test.Provider

  public abstract class test.Assert
  public abstract class test.Outcome

  public class test.Args
  public class test.AssertionFailed
  public class test.Ignore
  public class test.Values
}
```