### PR TITLE
Implement checking for expected exceptions' messages

### DIFF
--- a/src/main/php/test/Expect.class.php
+++ b/src/main/php/test/Expect.class.php
@@ -1,0 +1,40 @@
+<?php namespace test;
+
+use lang\Throwable;
+
+/**
+ * Expected exceptions
+ * 
+ * - Any message: `Expect(IllegalArgumentException::class)`
+ * - Exact message: `Expect(IllegalArgumentException::class, 'Test')`
+ * - Message matching pattern: `Expect(IllegalArgumentException::class, '/Test/')`
+ *
+ * @test  test.unittest.ExpectTest
+ */
+class Expect {
+  private $class, $message;
+
+  /**
+   * Creates a values annotation
+   *
+   * @param  string $class
+   * @param  ?string $message
+   */
+  public function __construct($class= [], $message= null) {
+    $this->class= $class;
+    $this->message= $message;
+  }
+
+  /** Check whether this expectation is met by the given throwable */
+  public function metBy(Throwable $t): bool {
+    $instance= $t instanceof $this->class;
+
+    if (null === $this->message) {
+      return $instance;
+    } else if ('/' === ($this->message[0] ?? '')) {
+      return $instance && preg_match($this->message, $t->getMessage());
+    } else {
+      return $instance && $this->message === $t->getMessage();
+    }
+  }
+}

--- a/src/main/php/test/Expect.class.php
+++ b/src/main/php/test/Expect.class.php
@@ -37,4 +37,16 @@ class Expect {
       return $instance && $this->message === $t->getMessage();
     }
   }
+
+  /** @return string */
+  public function pattern() {
+    $pattern= strtr($this->class, '\\', '.');
+    if (null === $this->message) {
+      return $pattern;
+    } else if ('/' === ($this->message[0] ?? '')) {
+      return "{$pattern}({$this->message})";
+    } else {
+      return "{$pattern}('{$this->message}'')";
+    }
+  }
 }

--- a/src/main/php/test/execution/RunTest.class.php
+++ b/src/main/php/test/execution/RunTest.class.php
@@ -4,13 +4,13 @@ use Throwable as Any;
 use lang\reflection\Type;
 use lang\{Throwable, Runnable};
 use test\outcome\{Succeeded, Skipped, Failed};
-use test\{Outcome, Prerequisite};
+use test\{Expect, Outcome, Prerequisite};
 use util\Objects;
 
 class RunTest implements Runnable {
   private $name, $run;
   private $prerequisites= [];
-  private $expecting= null;
+  private $expectation= null;
   private $arguments= [];
 
   public function __construct(string $name, callable $run) {
@@ -33,14 +33,13 @@ class RunTest implements Runnable {
   }
 
   /**
-   * Sets an expected exception type
+   * Sets an expected exception
    *
-   * @param  Type $type
-   * @param  ?string $message
+   * @param  Expect $expectation
    * @return self
    */
-  public function expecting(Type $type, $message= null) {
-    $this->expecting= [$type, $message];
+  public function expecting(Expect $expectation) {
+    $this->expectation= $expectation;
     return $this;
   }
 
@@ -69,9 +68,8 @@ class RunTest implements Runnable {
       return new Succeeded($this->name);
     } catch (Any $e) {
       $t= Throwable::wrap($e);
-      if (list($type, $message)= $this->expecting) {
-        if ($type->isInstance($t)) return new Succeeded($this->name);
-      }
+      if ($this->expectation && $this->expectation->metBy($t)) return new Succeeded($this->name);
+
       return new Failed($this->name, $t);
     }
   }

--- a/src/main/php/test/execution/TestClass.class.php
+++ b/src/main/php/test/execution/TestClass.class.php
@@ -49,7 +49,7 @@ class TestClass extends Group {
     }
 
     // Enumerate methods
-    $before= $after= $cases= [];
+    $before= $after= $execute= [];
     foreach ($this->context->type->methods() as $method) {
       $annotations= $method->annotations();
 
@@ -79,14 +79,14 @@ class TestClass extends Group {
         $provider= null;
         foreach ($annotations->all(Provider::class) as $annotation) {
           $provider= $annotation->newInstance();
-          $cases[]= function() use($case, $provider) {
+          $execute[]= function() use($case, $provider) {
             foreach ($provider->values($this->context) as $arguments) {
               yield (clone $case)->passing($arguments);
             }
           };
         }
 
-        $provider || $cases[]= function() use($case) { yield $case; };
+        $provider || $execute[]= function() use($case) { yield $case; };
       }
     }
 
@@ -96,7 +96,7 @@ class TestClass extends Group {
       $method->invoke($this->context->instance, [], $this->context->type);
     }
 
-    foreach ($cases as $variations) {
+    foreach ($execute as $variations) {
       yield from $variations();
     }
 

--- a/src/main/php/test/execution/TestClass.class.php
+++ b/src/main/php/test/execution/TestClass.class.php
@@ -72,7 +72,7 @@ class TestClass extends Group {
 
         // Check expected exceptions
         if ($expect= $annotations->type(Expect::class)) {
-          $case->expecting(Reflection::type($expect->argument('class') ?? $expect->argument(0)));
+          $case->expecting($expect->newInstance());
         }
 
         // For each provider, create test case variations from the values it provides

--- a/src/main/php/test/execution/TestClass.class.php
+++ b/src/main/php/test/execution/TestClass.class.php
@@ -79,14 +79,14 @@ class TestClass extends Group {
         $provider= null;
         foreach ($annotations->all(Provider::class) as $annotation) {
           $provider= $annotation->newInstance();
-          $execute[]= function() use($case, $provider) {
+          $execute[]= (function() use($case, $provider) {
             foreach ($provider->values($this->context) as $arguments) {
               yield (clone $case)->passing($arguments);
             }
-          };
+          })();
         }
 
-        $provider || $execute[]= function() use($case) { yield $case; };
+        $provider || $execute[]= [$case];
       }
     }
 
@@ -96,8 +96,8 @@ class TestClass extends Group {
       $method->invoke($this->context->instance, [], $this->context->type);
     }
 
-    foreach ($execute as $variations) {
-      yield from $variations();
+    foreach ($execute as $cases) {
+      yield from $cases;
     }
 
     foreach ($after as $method) {

--- a/src/main/php/test/outcome/Failed.class.php
+++ b/src/main/php/test/outcome/Failed.class.php
@@ -4,12 +4,24 @@ use lang\Throwable;
 use test\Outcome;
 
 class Failed extends Outcome {
-  public $cause;
+  public $reason, $cause;
 
-  public function __construct($test, Throwable $cause) {
+  public function __construct($test, $reason, Throwable $cause= null) {
     parent::__construct($test);
+    $this->reason= $reason;
     $this->cause= $cause;
   }
 
   public function kind() { return 'failure'; }
+
+  /** @return string */
+  public function trace($indent= '') {
+    if (null === $this->cause) return "{$indent}No exception raised";
+
+    $s= '';
+    foreach ($this->cause->getStackTrace() as $trace) {
+      $s.= $indent.ltrim($trace->toString());
+    }
+    return rtrim($s);
+  }
 }

--- a/src/main/php/xp/test/Runner.class.php
+++ b/src/main/php/xp/test/Runner.class.php
@@ -149,8 +149,8 @@ class Runner {
           case 'success': Console::writeLine(); break;
           case 'skipped': Console::writeLinef("\033[1;32;3m // Skip: %s\033[0m", $outcome->reason); break;
           case 'failure': {
-            Console::writeLinef("\033[1;32;3m // Fail: %s\033[0m", $outcome->cause->getMessage());
-            $failures[$group->name().'::'.$outcome->test]= $outcome->cause;
+            Console::writeLinef("\033[1;32;3m // Fail: %s\033[0m", $outcome->reason);
+            $failures[$group->name().'::'.$outcome->test]= $outcome;
             break;
           }
         }
@@ -168,8 +168,13 @@ class Runner {
     }
 
     // ...finally, output all failures
-    foreach ($failures as $location => $exception) {
-      Console::writeLinef("\033[31m⨯ %s\033[0m\n  %s\n", $location, Objects::stringOf($exception, '  '));
+    foreach ($failures as $location => $failure) {
+      Console::writeLinef(
+        "\033[31m⨯ %s\033[0m\n  \033[37;1m%s\033[0m\n%s\n",
+        $location,
+        $failure->reason,
+        $failure->trace('    ')
+      );
     }
 
     // Print out summary of test run

--- a/src/test/php/test/unittest/ExpectTest.class.php
+++ b/src/test/php/test/unittest/ExpectTest.class.php
@@ -1,0 +1,32 @@
+<?php namespace test\unittest;
+
+use lang\{IllegalArgumentException, IllegalStateException};
+use test\source\Sources;
+use test\{Assert, Expect, Test, Values};
+
+class ExpectTest {
+
+  #[Test]
+  public function not_met() {
+    $expectation= new Expect(IllegalArgumentException::class);
+    Assert::false($expectation->metBy(new IllegalStateException('Test')));
+  }
+
+  #[Test]
+  public function met() {
+    $expectation= new Expect(IllegalArgumentException::class);
+    Assert::true($expectation->metBy(new IllegalArgumentException('Test')));
+  }
+
+  #[Test, Values([['Test', true], ['Unmet', false]])]
+  public function met_with_message($message, $outcome) {
+    $expectation= new Expect(IllegalArgumentException::class, 'Test');
+    Assert::equals($outcome, $expectation->metBy(new IllegalArgumentException($message)));
+  }
+
+  #[Test, Values([['Test', true], ['A test', true], ['Testing', true], ['Unmet', false]])]
+  public function met_with_pattern($message, $outcome) {
+    $expectation= new Expect(IllegalArgumentException::class, '/[Tt]est.*/');
+    Assert::equals($outcome, $expectation->metBy(new IllegalArgumentException($message)));
+  }
+}


### PR DESCRIPTION
- Any message: `Expect(IllegalArgumentException::class)`
- Exact message: `Expect(IllegalArgumentException::class, 'Test')`
- Message matching pattern: `Expect(IllegalArgumentException::class, '/Test/')`
