### PR TITLE
Only verify parameterized test cases' prerequisites once

### DIFF
--- a/src/main/php/test/Values.class.php
+++ b/src/main/php/test/Values.class.php
@@ -31,9 +31,12 @@ class Values implements Provider {
    * @return iterable
    */
   public function values(Context $context) {
-    return null === $this->from
+    $it= null === $this->from
       ? $this->list
       : $context->type->method($this->from)->invoke($context->instance, [], $context->type)
     ;
+    foreach ($it as $arguments) {
+      yield is_array($arguments) ? $arguments : [$arguments];
+    }
   }
 }

--- a/src/main/php/test/Values.class.php
+++ b/src/main/php/test/Values.class.php
@@ -31,12 +31,9 @@ class Values implements Provider {
    * @return iterable
    */
   public function values(Context $context) {
-    $it= null === $this->from
+    return null === $this->from
       ? $this->list
       : $context->type->method($this->from)->invoke($context->instance, [], $context->type)
     ;
-    foreach ($it as $arguments) {
-      yield is_array($arguments) ? $arguments : [$arguments];
-    }
   }
 }

--- a/src/main/php/test/execution/Once.class.php
+++ b/src/main/php/test/execution/Once.class.php
@@ -7,5 +7,5 @@ class Once {
   public function __construct($case) { $this->case= $case; }
 
   /** @return iterable */
-  public function cases() { return [new RunTest($this->case, [])]; }
+  public function runnables() { return [new RunTest($this->case, [])]; }
 }

--- a/src/main/php/test/execution/Once.class.php
+++ b/src/main/php/test/execution/Once.class.php
@@ -1,0 +1,11 @@
+<?php namespace test\execution;
+
+class Once {
+  public $case;
+
+  /** @param TestCase $case */
+  public function __construct($case) { $this->case= $case; }
+
+  /** @return iterable */
+  public function cases() { return [new RunTest($this->case, [])]; }
+}

--- a/src/main/php/test/execution/Once.class.php
+++ b/src/main/php/test/execution/Once.class.php
@@ -7,5 +7,5 @@ class Once {
   public function __construct($case) { $this->case= $case; }
 
   /** @return iterable */
-  public function runnables() { return [new RunTest($this->case, [])]; }
+  public function targets() { return [new RunTest($this->case, [])]; }
 }

--- a/src/main/php/test/execution/Provided.class.php
+++ b/src/main/php/test/execution/Provided.class.php
@@ -15,7 +15,7 @@ class Provided {
   }
 
   /** @return iterable */
-  public function cases() {
+  public function runnables() {
     foreach ($this->provider as $arguments) {
       yield new RunTest($this->case, is_array($arguments) ? $arguments : [$arguments]);
     }

--- a/src/main/php/test/execution/Provided.class.php
+++ b/src/main/php/test/execution/Provided.class.php
@@ -1,0 +1,23 @@
+<?php namespace test\execution;
+
+class Provided {
+  public $case, $provider;
+
+  /**
+   * Creates a new instance
+   *
+   * @param TestCase $case
+   * @param iterable $provider
+   */
+  public function __construct($case, $provider) {
+    $this->case= $case;
+    $this->provider= $provider;
+  }
+
+  /** @return iterable */
+  public function cases() {
+    foreach ($this->provider as $arguments) {
+      yield new RunTest($this->case, is_array($arguments) ? $arguments : [$arguments]);
+    }
+  }
+}

--- a/src/main/php/test/execution/Provided.class.php
+++ b/src/main/php/test/execution/Provided.class.php
@@ -15,7 +15,7 @@ class Provided {
   }
 
   /** @return iterable */
-  public function runnables() {
+  public function targets() {
     foreach ($this->provider as $arguments) {
       yield new RunTest($this->case, is_array($arguments) ? $arguments : [$arguments]);
     }

--- a/src/main/php/test/execution/RunTest.class.php
+++ b/src/main/php/test/execution/RunTest.class.php
@@ -1,87 +1,27 @@
 <?php namespace test\execution;
 
-use Throwable as Any;
-use lang\reflection\Type;
-use lang\{Throwable, Runnable};
-use test\outcome\{Succeeded, Skipped, Failed};
-use test\{AssertionFailed, Expect, Outcome, Prerequisite};
-use util\Objects;
+use lang\Runnable;
+use test\Outcome;
 
 class RunTest implements Runnable {
-  private $name, $run;
-  private $prerequisites= [];
-  private $expectation= null;
-  private $arguments= [];
+  private $case, $arguments;
 
-  public function __construct(string $name, callable $run) {
-    $this->name= $name;
-    $this->run= $run;
+  /**
+   * Runs a given test case with the supplied arguments
+   *
+   * @param  TestCase $case
+   * @param  array<mixed> $arguments
+   */
+  public function __construct($case, $arguments) {
+    $this->case= $case;
+    $this->arguments= $arguments;
   }
 
   /** @return string */
-  public function name() { return $this->name; }
-
-  /**
-   * Sets an expected exception type
-   *
-   * @param  Prerequisite $prerequisite
-   * @return self
-   */
-  public function verify(Prerequisite $prerequisite) {
-    $this->prerequisites[]= $prerequisite;
-    return $this;
-  }
-
-  /**
-   * Sets an expected exception
-   *
-   * @param  Expect $expectation
-   * @return self
-   */
-  public function expecting(Expect $expectation) {
-    $this->expectation= $expectation;
-    return $this;
-  }
-
-  /**
-   * Passes arguments. Suffixes this test case's name with a comma-separted list
-   * of string representations of the given arguments enclosed in square brackets.
-   *
-   * @param  array|mixed $arguments
-   * @return self
-   */
-  public function passing($arguments) {
-    $this->arguments= is_array($arguments) ? $arguments : [$arguments];
-    $this->name.= Objects::stringOf($this->arguments);
-    return $this;
-  }
+  public function name() { return $this->case->name(); }
 
   /** Runs this test case and returns its outcome */
   public function run(): Outcome {
-    foreach ($this->prerequisites as $prerequisite) {
-      if (!$prerequisite->verify()) return new Skipped($this->name, $prerequisite->requirement(false));
-    }
-
-    \xp::gc();
-    try {
-      ($this->run)(...$this->arguments);
-
-      if (null === $this->expectation) {
-        return new Succeeded($this->name);
-      } else {
-        return new Failed($this->name, 'Did not catch expected '.$this->expectation->pattern(), null);
-      }
-    } catch (Any $e) {
-      $t= Throwable::wrap($e);
-
-      if (null === $this->expectation) {
-        $reason= $t instanceof AssertionFailed ? $t->getMessage() : 'Unexpected '.lcfirst($t->compoundMessage());
-        return new Failed($this->name, $reason, $t);
-      } else if (!$this->expectation->metBy($t)) {
-        return new Failed($this->name, 'Did not catch expected '.$this->expectation->pattern(), $t);
-      } else {
-        return new Succeeded($this->name);
-      }
-    }
+    return $this->case->run($this->arguments);
   }
 }

--- a/src/main/php/test/execution/TestCase.class.php
+++ b/src/main/php/test/execution/TestCase.class.php
@@ -27,7 +27,7 @@ class TestCase {
   public function prerequisites() { return $this->prerequisites; }
 
   /**
-   * Sets an expected exception type
+   * Verifies a given prerequisite
    *
    * @param  Prerequisite $prerequisite
    * @return self
@@ -48,8 +48,13 @@ class TestCase {
     return $this;
   }
 
-  /** Runs this test case and returns its outcome */
-  public function run($arguments= []): Outcome {
+  /**
+   * Runs this test case and returns its outcome
+   *
+   * @param  array<mixed> $arguments
+   * @return Outcome
+   */
+  public function run($arguments= []) {
     \xp::gc();
     try {
       if ($arguments) {

--- a/src/main/php/test/execution/TestCase.class.php
+++ b/src/main/php/test/execution/TestCase.class.php
@@ -1,0 +1,81 @@
+<?php namespace test\execution;
+
+use Throwable as Any;
+use lang\reflection\Type;
+use lang\{Throwable, Runnable};
+use test\outcome\{Succeeded, Skipped, Failed};
+use test\{AssertionFailed, Expect, Outcome, Prerequisite};
+use util\Objects;
+
+class TestCase {
+  private $name, $run;
+  private $expectation= null;
+  private $prerequisites= [];
+
+  public function __construct(string $name, callable $run) {
+    $this->name= $name;
+    $this->run= $run;
+  }
+
+  /** @return string */
+  public function name() { return $this->name; }
+
+  /** @return ?Expect */
+  public function expectation() { return $this->expectation; }
+
+  /** @return array<Prerequisite> */
+  public function prerequisites() { return $this->prerequisites; }
+
+  /**
+   * Sets an expected exception type
+   *
+   * @param  Prerequisite $prerequisite
+   * @return self
+   */
+  public function verifying(Prerequisite $prerequisite) {
+    $this->prerequisites[]= $prerequisite;
+    return $this;
+  }
+
+  /**
+   * Sets an expected exception
+   *
+   * @param  Expect $expectation
+   * @return self
+   */
+  public function expecting(Expect $expectation) {
+    $this->expectation= $expectation;
+    return $this;
+  }
+
+  /** Runs this test case and returns its outcome */
+  public function run($arguments= []): Outcome {
+    \xp::gc();
+    try {
+      if ($arguments) {
+        $name= $this->name.Objects::stringOf($arguments);
+        ($this->run)(...$arguments);
+      } else {
+        $name= $this->name;
+        ($this->run)();
+      }
+
+      if (null === $this->expectation) {
+        return new Succeeded($name);
+      } else {
+        return new Failed($name, 'Did not catch expected '.$this->expectation->pattern(), null);
+      }
+    } catch (Any $e) {
+      $t= Throwable::wrap($e);
+
+      if (null === $this->expectation) {
+        $reason= $t instanceof AssertionFailed ? $t->getMessage() : 'Unexpected '.lcfirst($t->compoundMessage());
+        return new Failed($name, $reason, $t);
+      } else if (!$this->expectation->metBy($t)) {
+        return new Failed($name, 'Did not catch expected '.$this->expectation->pattern(), $t);
+      } else {
+        return new Succeeded($name);
+      }
+    }
+  }
+}

--- a/src/main/php/test/execution/TestClass.class.php
+++ b/src/main/php/test/execution/TestClass.class.php
@@ -92,14 +92,14 @@ class TestClass extends Group {
       $method->invoke($this->context->instance, [], $this->context->type);
     }
 
-    foreach ($execute as $target) {
-      foreach ($target->case->prerequisites() as $prerequisite) {
+    foreach ($execute as $run) {
+      foreach ($run->case->prerequisites() as $prerequisite) {
         if ($prerequisite->verify()) continue;
-        yield new SkipTest($target->case->name(), $prerequisite->requirement(false));
+        yield new SkipTest($run->case->name(), $prerequisite->requirement(false));
         continue 2;
       }
 
-      yield from $target->runnables();
+      yield from $run->targets();
     }
 
     foreach ($after as $method) {

--- a/src/main/php/test/execution/TestClass.class.php
+++ b/src/main/php/test/execution/TestClass.class.php
@@ -95,11 +95,11 @@ class TestClass extends Group {
     foreach ($execute as $target) {
       foreach ($target->case->prerequisites() as $prerequisite) {
         if ($prerequisite->verify()) continue;
-        yield new SkipTest($case->name(), $prerequisite->requirement(false));
+        yield new SkipTest($target->case->name(), $prerequisite->requirement(false));
         continue 2;
       }
 
-      yield from $target->cases();
+      yield from $target->runnables();
     }
 
     foreach ($after as $method) {


### PR DESCRIPTION
Implements feature suggested in #10

Compiler test suite before:
```
Test cases:  902 succeeded, 4 skipped
Memory used: 11045.63 kB (11099.76 kB peak)
Time taken:  0.322 seconds (2.269 seconds overall)
```

Compiler test suite after:
```
Test cases:  902 succeeded, 4 skipped
Memory used: 11053.50 kB (11107.63 kB peak)
Time taken:  0.267 seconds (1.788 seconds overall)
```