### PR TITLE
Fix errors occuring during setup not being correctly reported

### DIFF
--- a/src/main/php/test/execution/GroupFailed.class.php
+++ b/src/main/php/test/execution/GroupFailed.class.php
@@ -1,6 +1,7 @@
 <?php namespace test\execution;
 
 use lang\{Throwable, XPException};
+use test\outcome\Failed;
 
 /** Indicates a failure on the test group - e.g., during instantiation */
 class GroupFailed extends XPException {
@@ -10,5 +11,10 @@ class GroupFailed extends XPException {
   public function __construct(string $origin, Throwable $cause) {
     parent::__construct('Exception from '.$origin, $cause);
     $this->origin= $origin;
+  }
+
+  /** @return Failed */
+  public function failure() {
+    return new Failed($this->origin, 'Unexpected '.lcfirst($this->cause->compoundMessage()), $this->cause);
   }
 }

--- a/src/main/php/test/execution/TestClass.class.php
+++ b/src/main/php/test/execution/TestClass.class.php
@@ -88,8 +88,12 @@ class TestClass extends Group {
 
     // Run all @Before methods, then yield the test cases, then finalize
     // with the methods annotated with @After
-    foreach ($before as $method) {
-      $method->invoke($this->context->instance, [], $this->context->type);
+    try {
+      foreach ($before as $method) {
+        $method->invoke($this->context->instance, [], $this->context->type);
+      }
+    } catch (InvocationFailed $e) {
+      throw new GroupFailed($e->target()->compoundName(), $e->getCause());
     }
 
     foreach ($execute as $run) {

--- a/src/main/php/xp/test/Runner.class.php
+++ b/src/main/php/xp/test/Runner.class.php
@@ -131,7 +131,7 @@ class Runner {
           );
         }
       } catch (GroupFailed $f) {
-        $failures[$f->origin]= $f->getCause();
+        $failures[$f->origin]= $f->failure();
         $metrics->count['failure']++;
         Console::writeLinef(
           "\r> %s \033[37m%s\033[1;32;3m // %s\033[0m",


### PR DESCRIPTION
Exceptions from `#[Before]` methods:

### Before

![Screenshot with uncaught exception](https://user-images.githubusercontent.com/696742/217104164-881d0ed7-a33e-4abd-8985-f2694a8768ee.png)

### After

![Screenshot with correct exception handling](https://user-images.githubusercontent.com/696742/217103711-eb28b57a-3c79-467d-8cbc-64d683033a96.png)
