### PR TITLE
Declare Test, After and Before annotations

### DIFF
--- a/src/main/php/test/After.class.php
+++ b/src/main/php/test/After.class.php
@@ -1,0 +1,6 @@
+<?php namespace test;
+
+/** After annotation */
+class After {
+
+}

--- a/src/main/php/test/Before.class.php
+++ b/src/main/php/test/Before.class.php
@@ -1,0 +1,6 @@
+<?php namespace test;
+
+/** Before annotation */
+class Before {
+
+}

--- a/src/main/php/test/Test.class.php
+++ b/src/main/php/test/Test.class.php
@@ -1,0 +1,6 @@
+<?php namespace test;
+
+/** Test annotation */
+class Test {
+
+}


### PR DESCRIPTION
Prevents repeated class loader lookups when executing the test suite, and improves performance in doing so.

Class loading is triggered by the call to *is_subclass_of()* in the reflection library's `lang.reflect.Annotations` class:

```php
public function all($type) {
  // ...shortened for brevity

  foreach ($this->annotations as $type => $arguments) {
    if ($type === $compare || is_subclass_of($type, $compare)) {
      yield $type => new Annotation($type, $arguments);
    }
  }
}
```

An alternative would be to change the reflection library to test for *class_exists() || interface_exists()* on the passed type, and return false, potentially causing subtle breaks though. Also, by declaring these annotations, we make static analyzers like phpstan happy.