### PR TITLE
Add assertion helpers for thrown exceptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         ini-values: date.timezone=Europe/Berlin
 
-    - name: Setup Problem Matchers for PHP
-      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
     - name: Validate composer.json and composer.lock
       run: composer validate
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following shorthand methods exist on the `Assert` class:
 * `false(mixed $actual)`  - check a given value is equal to the *false* boolean
 * `null(mixed $actual)` - check a given value is *null*
 * `instance(string|lang.Type $expected, mixed $actual)` - check a given value is an instance of the given type.
+* `throws(string|lang.Type $expected, callable $actual)` - verify the given callable raises an exception.
 
 Expected failures
 -----------------

--- a/src/main/php/test/Assert.class.php
+++ b/src/main/php/test/Assert.class.php
@@ -77,4 +77,15 @@ abstract class Assert {
   public static function instance($expected, $actual) {
     (new Assertable($actual))->is(new Instance($expected));
   }
+
+  /**
+   * Throws shorthand
+   *
+   * @param  string|Type $expected
+   * @param  callable $actual
+   * @return void
+   */
+  public static function throws($expected, $actual) {
+    (new Assertable($actual))->throws($expected);
+  }
 }

--- a/src/main/php/test/Expect.class.php
+++ b/src/main/php/test/Expect.class.php
@@ -38,8 +38,8 @@ class Expect {
     }
   }
 
-  /** @return string */
-  public function pattern() {
+  /** Returns pattern for this expectation */
+  public function pattern(): string {
     $pattern= strtr($this->class, '\\', '.');
     if (null === $this->message) {
       return $pattern;
@@ -48,5 +48,10 @@ class Expect {
     } else {
       return "{$pattern}('{$this->message}')";
     }
+  }
+
+  /** Returns pattern for a given exception */
+  public static function patternOf(Throwable $t): string {
+    return nameof($t)."('{$t->getMessage()}')";
   }
 }

--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -1,8 +1,9 @@
 <?php namespace test\assert;
 
-use Closure, Throwable, Traversable, ReflectionFunction, ReflectionMethod;
-use lang\{Type, IllegalArgumentException};
-use test\AssertionFailed;
+use Closure, Traversable, ReflectionFunction, ReflectionMethod;
+use Throwable as Any;
+use lang\{Type, Throwable, IllegalArgumentException};
+use test\{AssertionFailed, Expect};
 
 /** @test test.unittest.AssertableTest */
 class Assertable {
@@ -60,7 +61,7 @@ class Assertable {
       if (1 === $r->getNumberOfRequiredParameters()) {
         $mapper= function($value, $key) use($mapper) { return $mapper($value); };
       }
-    } catch (Throwable $e) {
+    } catch (Any $e) {
       throw new IllegalArgumentException($e->getMessage(), $e);
     }
 
@@ -138,5 +139,31 @@ class Assertable {
    */
   public function isInstanceOf($type) {
     return $this->is(new Instance($type));
+  }
+
+  /**
+   * Assert a given exception is thrown by the callable value
+   *
+   * @param  string|Type $type
+   * @param  ?string $message
+   * @return self
+   */
+  public function throws($type, $message= null) {
+    $expect= new Expect($type instanceof Type ? $type->literal() : $type, $message);
+    try {
+      ($this->value)();
+    } catch (Any $e) {
+      $t= Throwable::wrap($e);
+      if ($expect->metBy($t)) return $this;
+
+      throw new AssertionFailed(sprintf(
+        "%s was thrown, have %s ('%s') instead",
+        $expect->pattern(),
+        nameof($t),
+        $t->getMessage()
+      ));
+    }
+
+    throw new AssertionFailed($expect->pattern().' was thrown');
   }
 }

--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -155,10 +155,10 @@ class Assertable {
     } catch (Any $e) {
       $t= Throwable::wrap($e);
       if ($expect->metBy($t)) return $this;
+
       throw new AssertionFailed($expect->pattern().' was thrown, caught '.Expect::patternOf($t).' instead');
     }
 
-    // No exception was raised
-    throw new AssertionFailed($expect->pattern().' was thrown');
+    throw new AssertionFailed($expect->pattern().' was thrown, no exception occurred');
   }
 }

--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -155,15 +155,10 @@ class Assertable {
     } catch (Any $e) {
       $t= Throwable::wrap($e);
       if ($expect->metBy($t)) return $this;
-
-      throw new AssertionFailed(sprintf(
-        "%s was thrown, have %s ('%s') instead",
-        $expect->pattern(),
-        nameof($t),
-        $t->getMessage()
-      ));
+      throw new AssertionFailed($expect->pattern().' was thrown, caught '.Expect::patternOf($t).' instead');
     }
 
+    // No exception was raised
     throw new AssertionFailed($expect->pattern().' was thrown');
   }
 }

--- a/src/main/php/test/execution/TestCase.class.php
+++ b/src/main/php/test/execution/TestCase.class.php
@@ -80,7 +80,7 @@ class TestCase {
         $message= sprintf(
           "Did not catch expected %s, %s was thrown instead",
           $this->expectation->pattern(),
-          Expect::patternOf($t),
+          Expect::patternOf($t)
         );
         return new Failed($name, $message, $t);
       } else {

--- a/src/main/php/test/execution/TestCase.class.php
+++ b/src/main/php/test/execution/TestCase.class.php
@@ -77,7 +77,12 @@ class TestCase {
         $reason= $t instanceof AssertionFailed ? $t->getMessage() : 'Unexpected '.lcfirst($t->compoundMessage());
         return new Failed($name, $reason, $t);
       } else if (!$this->expectation->metBy($t)) {
-        return new Failed($name, 'Did not catch expected '.$this->expectation->pattern(), $t);
+        $message= sprintf(
+          "Did not catch expected %s, %s was thrown instead",
+          $this->expectation->pattern(),
+          Expect::patternOf($t),
+        );
+        return new Failed($name, $message, $t);
       } else {
         return new Succeeded($name);
       }

--- a/src/test/php/test/unittest/AssertableTest.class.php
+++ b/src/test/php/test/unittest/AssertableTest.class.php
@@ -107,7 +107,7 @@ class AssertableTest {
     $a->throws(IllegalArgumentException::class, '/[Tt]est/');
   }
 
-  #[Test, Expect(AssertionFailed::class, 'Failed asserting that lang.IllegalArgumentException was thrown')]
+  #[Test, Expect(AssertionFailed::class, 'Failed asserting that lang.IllegalArgumentException was thrown, no exception occurred')]
   public function nothing_thrown() {
     $a= new Assertable(function() { });
     $a->throws(IllegalArgumentException::class);

--- a/src/test/php/test/unittest/AssertableTest.class.php
+++ b/src/test/php/test/unittest/AssertableTest.class.php
@@ -113,13 +113,13 @@ class AssertableTest {
     $a->throws(IllegalArgumentException::class);
   }
 
-  #[Test, Expect(AssertionFailed::class, 'Failed asserting that lang.IllegalArgumentException was thrown, have lang.IllegalStateException (\'Test\') instead')]
+  #[Test, Expect(AssertionFailed::class, 'Failed asserting that lang.IllegalArgumentException was thrown, caught lang.IllegalStateException(\'Test\') instead')]
   public function incorrect_thrown_type() {
     $a= new Assertable(function() { throw new IllegalStateException('Test'); });
     $a->throws(IllegalArgumentException::class);
   }
 
-  #[Test, Expect(AssertionFailed::class, 'Failed asserting that lang.IllegalArgumentException(\'Test\') was thrown, have lang.IllegalArgumentException (\'Other\') instead')]
+  #[Test, Expect(AssertionFailed::class, 'Failed asserting that lang.IllegalArgumentException(\'Test\') was thrown, caught lang.IllegalArgumentException(\'Other\') instead')]
   public function incorrect_thrown_message() {
     $a= new Assertable(function() { throw new IllegalArgumentException('Other'); });
     $a->throws(IllegalArgumentException::class, 'Test');

--- a/src/test/php/test/unittest/AssertableTest.class.php
+++ b/src/test/php/test/unittest/AssertableTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace test\unittest;
 
-use lang\IllegalArgumentException;
+use lang\{IllegalArgumentException, IllegalStateException};
 use test\assert\Assertable;
 use test\{Assert, AssertionFailed, Expect, Test, Values};
 
@@ -87,5 +87,41 @@ class AssertableTest {
   #[Test, Expect(IllegalArgumentException::class)]
   public function illegal_callback() {
     (new Assertable(1))->mappedBy('not-a-function');
+  }
+
+  #[Test]
+  public function throws() {
+    $a= new Assertable(function() { throw new IllegalArgumentException('Test'); });
+    $a->throws(IllegalArgumentException::class);
+  }
+
+  #[Test]
+  public function throws_with_message() {
+    $a= new Assertable(function() { throw new IllegalArgumentException('Test'); });
+    $a->throws(IllegalArgumentException::class, 'Test');
+  }
+
+  #[Test]
+  public function throws_with_pattern() {
+    $a= new Assertable(function() { throw new IllegalArgumentException('Test'); });
+    $a->throws(IllegalArgumentException::class, '/[Tt]est/');
+  }
+
+  #[Test, Expect(AssertionFailed::class, 'Failed asserting that lang.IllegalArgumentException was thrown')]
+  public function nothing_thrown() {
+    $a= new Assertable(function() { });
+    $a->throws(IllegalArgumentException::class);
+  }
+
+  #[Test, Expect(AssertionFailed::class, 'Failed asserting that lang.IllegalArgumentException was thrown, have lang.IllegalStateException (\'Test\') instead')]
+  public function incorrect_thrown_type() {
+    $a= new Assertable(function() { throw new IllegalStateException('Test'); });
+    $a->throws(IllegalArgumentException::class);
+  }
+
+  #[Test, Expect(AssertionFailed::class, 'Failed asserting that lang.IllegalArgumentException(\'Test\') was thrown, have lang.IllegalArgumentException (\'Other\') instead')]
+  public function incorrect_thrown_message() {
+    $a= new Assertable(function() { throw new IllegalArgumentException('Other'); });
+    $a->throws(IllegalArgumentException::class, 'Test');
   }
 }


### PR DESCRIPTION
This pull request supplements [expected failure annotations](https://github.com/xp-framework/test#expected-failures) for cases when we want to narrow down very precisely what part of the test code is causing the exception. There are two APIs:

1. The simple `Assert::throws()` shorthand which can only test for the exception type
2. The `Assert::that(...)` *throws* assertion which can also test for exception message, just like `#[Expect]`

## Usage

```php
use lang\IllegalArgumentException;
use test\{Assert, Test};

class ThrownTest {

  #[Test]
  public function shorthand() {
    $fixture= function() { /* ... */ };
    Assert::throws(IllegalArgumentException::class, $fixture);
  }

  #[Test]
  public function throws_exception() {
    $fixture= function() { /* ... */ };
    Assert::that($fixture)->throws(IllegalArgumentException::class);
  }

  #[Test]
  public function throws_exception_with_message() {
    $fixture= function() { /* ... */ };
    Assert::that($fixture)->throws(IllegalArgumentException::class, 'Given argument does not...');
  }

  #[Test]
  public function throws_exception_with_pattern() {
    $fixture= function() { /* ... */ };
    Assert::that($fixture)->throws(IllegalArgumentException::class, '/^Given argument .+ does not/');
  }
}
```