### PR TITLE
Allow mappers to use NULL keys for appending to the result

### DIFF
--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -70,7 +70,13 @@ class Assertable {
       foreach ($this->value as $key => $element) {
         $m= $mapper($element, $key);
         if ($m instanceof Traversable) {
-          $self->value+= iterator_to_array($m);
+          foreach ($m as $key => $value) {
+            if (null === $key) {
+              $self->value[]= $value;
+            } else {
+              $self->value[$key]= $value;
+            }
+          }
         } else if (is_string($key)) {
           $self->value[$key]= $m;
         } else {

--- a/src/main/php/test/assert/Assertable.class.php
+++ b/src/main/php/test/assert/Assertable.class.php
@@ -8,7 +8,7 @@ use test\{AssertionFailed, Expect};
 /** @test test.unittest.AssertableTest */
 class Assertable {
   public static $TRUE, $FALSE, $NULL;
-  private $value;
+  public $value;
 
   static function __static() {
 

--- a/src/test/php/test/unittest/AssertableTest.class.php
+++ b/src/test/php/test/unittest/AssertableTest.class.php
@@ -79,8 +79,22 @@ class AssertableTest {
   #[Test]
   public function map_can_transform_keys_via_yield() {
     Assert::equals(
-      new Assertable([1 => 'a', 2 => 'b']),
-      (new Assertable(['a' => 1, 'b' => 2]))->mappedBy(function($v, $k) { yield $v => $k; })
+      new Assertable([1 => 'a', 2 => 'b', 0 => 'c']),
+      (new Assertable(['a' => 1, 'b' => 2, 'c' => 0]))->mappedBy(function($v, $k) { yield $v => $k; })
+    );
+  }
+
+  #[Test]
+  public function yield_with_explicit_null_appends_to_result() {
+    $opcodes= function() {
+      yield 'const'    => 1;
+      yield 'add'      => 1;
+      yield 'multiply' => 2;
+      yield 'add'      => -1;
+    };
+    Assert::equals(
+      new Assertable([['const', 1], ['add', 1], ['multiply', 2], ['add', -1]]),
+      (new Assertable($opcodes()))->mappedBy(function($arg, $op) { yield null => [$op, $arg]; })
     );
   }
 


### PR DESCRIPTION
By using an explicit `null` in yield we can append to the result instead. 

*Note: Unfortunately, we cannot distinguish `yield $value` and `yield 0 => $value` from each other at runtime, or else we would've used the short form for this behaviour, while interpreting the one with the explicit 0 as setting `$result[0]`.*

## Example

```php
$opcodes= function() {
  yield 'const'    => 1;
  yield 'add'      => 1;
  yield 'multiply' => 2;
  yield 'add'      => -1;
};
$a= (new Assertable($opcodes()))->mappedBy(function($arg, $op) { yield null => [$op, $arg]; });
$a->value; // [['const', 1], ['add', 1], ['multiply', 2], ['add', -1]]
```