### PR TITLE
Make warnings raised during test execution fail these tests

### DIFF
--- a/src/main/php/test/Warnings.class.php
+++ b/src/main/php/test/Warnings.class.php
@@ -1,0 +1,40 @@
+<?php namespace test;
+
+use lang\{Throwable, StackTraceElement};
+
+class Warnings extends Throwable {
+  private static $LEVELS= [
+    E_ERROR             => 'E_ERROR',
+    E_WARNING           => 'E_WARNING',
+    E_PARSE             => 'E_PARSE',
+    E_NOTICE            => 'E_NOTICE',
+    E_CORE_ERROR        => 'E_CORE_ERROR',
+    E_CORE_WARNING      => 'E_CORE_WARNING',
+    E_COMPILE_ERROR     => 'E_COMPILE_ERROR',
+    E_COMPILE_WARNING   => 'E_COMPILE_WARNING',
+    E_USER_ERROR        => 'E_USER_ERROR',
+    E_USER_WARNING      => 'E_USER_WARNING',
+    E_USER_NOTICE       => 'E_USER_NOTICE',
+    E_STRICT            => 'E_STRICT',
+    E_RECOVERABLE_ERROR => 'E_RECOVERABLE_ERROR',
+    E_DEPRECATED        => 'E_DEPRECATED',
+    E_USER_DEPRECATED   => 'E_USER_DEPRECATED',
+  ];
+
+  /** Creates a new warnings instance */
+  public function __construct(array $warnings) {
+    $message= '';
+    foreach ($warnings as $warning) {
+      $message.= ', '.$warning[1];
+      $this->trace[]= new StackTraceElement(
+        $warning[2],
+        null,
+        '@error',
+        $warning[3],
+        [],
+        (self::$LEVELS[$warning[0]] ?? 'E_UNKNOWN('.$warning[0].')').': '.$warning[1]
+      );
+    }
+    parent::__construct(substr($message, 2));
+  }
+}

--- a/src/main/php/test/execution/TestCase.class.php
+++ b/src/main/php/test/execution/TestCase.class.php
@@ -58,6 +58,7 @@ class TestCase {
     $warnings= [];
     set_error_handler(function($kind, $message, $file, $line) use(&$warnings) {
       $warnings[]= [$kind, $message, $file, $line];
+      __error($kind, $message, $file, $line);
     });
     try {
       if ($arguments) {
@@ -71,6 +72,7 @@ class TestCase {
       if ($this->expectation) {
         return new Failed($name, 'Did not catch expected '.$this->expectation->pattern(), null);
       } else if ($warnings) {
+        \xp::gc();
         return new Failed($name, 'Succeeded but raised warnings', new Warnings($warnings));
       } else {
         return new Succeeded($name);

--- a/src/main/php/test/execution/TestCase.class.php
+++ b/src/main/php/test/execution/TestCase.class.php
@@ -73,7 +73,7 @@ class TestCase {
         return new Failed($name, 'Did not catch expected '.$this->expectation->pattern(), null);
       } else if ($warnings) {
         \xp::gc();
-        return new Failed($name, 'Succeeded but raised warnings', new Warnings($warnings));
+        return new Failed($name, 'Succeeded but raised '.sizeof($warnings).' warning(s)', new Warnings($warnings));
       } else {
         return new Succeeded($name);
       }

--- a/src/test/php/test/unittest/ExecutionTest.class.php
+++ b/src/test/php/test/unittest/ExecutionTest.class.php
@@ -79,6 +79,17 @@ class ExecutionTest {
   }
 
   #[Test]
+  public function tests_raising_warnings_fail() {
+    Assert::equals(['fixture' => Failed::class], $this->execute(new class() {
+
+      #[Test]
+      public function fixture() {
+        trigger_error('Test');
+      }
+    }));
+  }
+
+  #[Test]
   public function skipped_test() {
     Assert::equals(['fixture' => Skipped::class], $this->execute(new class() {
 

--- a/src/test/php/test/unittest/WarningsTest.class.php
+++ b/src/test/php/test/unittest/WarningsTest.class.php
@@ -33,9 +33,10 @@ class WarningsTest {
   public function fopen_nonexistant_file() {
     $r= $this->execute(function() { fopen('$', 'r'); });
 
-    Assert::that($r->cause->getStackTrace()[0]->message)
-      ->is(new Matches('/E_WARNING: fopen.+: No such file or directory/i'))
-    ;
+    Assert::matches(
+      '/E_WARNING: fopen.+: No such file or directory/i',
+      $r->cause->getStackTrace()[0]->message
+    );
   }
 
   #[Test]

--- a/src/test/php/test/unittest/WarningsTest.class.php
+++ b/src/test/php/test/unittest/WarningsTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace test\unittest;
 
+use test\assert\Matches;
 use test\execution\TestCase;
 use test\outcome\{Succeeded, Failed};
 use test\{Assert, Test};
@@ -31,10 +32,10 @@ class WarningsTest {
   #[Test]
   public function fopen_nonexistant_file() {
     $r= $this->execute(function() { fopen('$', 'r'); });
-    Assert::equals(
-      'E_WARNING: fopen($): Failed to open stream: No such file or directory',
-      $r->cause->getStackTrace()[0]->message
-    );
+
+    Assert::that($r->cause->getStackTrace()[0]->message)
+      ->is(new Matches('/E_WARNING: fopen.+: No such file or directory/i'))
+    ;
   }
 
   #[Test]

--- a/src/test/php/test/unittest/WarningsTest.class.php
+++ b/src/test/php/test/unittest/WarningsTest.class.php
@@ -1,0 +1,46 @@
+<?php namespace test\unittest;
+
+use test\execution\TestCase;
+use test\outcome\{Succeeded, Failed};
+use test\{Assert, Test};
+
+class WarningsTest {
+
+  /** Executes test function */
+  private function execute($function) {
+    return (new TestCase('test', $function))->run();
+  }
+
+  #[Test]
+  public function without_warnings() {
+    Assert::instance(Succeeded::class, $this->execute(function() { }));
+  }
+
+  #[Test]
+  public function trigger_error() {
+    $r= $this->execute(function() { trigger_error('Test'); });
+    Assert::equals('E_USER_NOTICE: Test', $r->cause->getStackTrace()[0]->message);
+  }
+
+  #[Test]
+  public function trigger_deprecation_error() {
+    $r= $this->execute(function() { trigger_error('Test', E_USER_DEPRECATED); });
+    Assert::equals('E_USER_DEPRECATED: Test', $r->cause->getStackTrace()[0]->message);
+  }
+
+  #[Test]
+  public function fopen_nonexistant_file() {
+    $r= $this->execute(function() { fopen('$', 'r'); });
+    Assert::equals(
+      'E_WARNING: fopen($): Failed to open stream: No such file or directory',
+      $r->cause->getStackTrace()[0]->message
+    );
+  }
+
+  #[Test]
+  public function multiple_warnings() {
+    $r= $this->execute(function() { trigger_error('One'); trigger_error('Two'); });
+    Assert::equals('E_USER_NOTICE: One', $r->cause->getStackTrace()[0]->message);
+    Assert::equals('E_USER_NOTICE: Two', $r->cause->getStackTrace()[1]->message);
+  }
+}


### PR DESCRIPTION
This pull request adds back a previously unported feature from `xp-framework/unittest`: Any warning raised within a test will mark the test as failed.

## Test

```php
use test\Test;

class WarningsTest {

  #[Test]
  public function raise() {
    trigger_error('Test', E_USER_DEPRECATED);
  }
}
```

## Output

![Output](https://github.com/xp-framework/test/assets/696742/fa1c18f1-9ff5-49f9-b4b1-40fa816b9413)

## See also

* https://github.com/xp-framework/unittest/pull/21
* https://github.com/xp-framework/rfc/issues/188