### PR TITLE
Implement Assert::matches()

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following shorthand methods exist on the `Assert` class:
 * `false(mixed $actual)`  - check a given value is equal to the *false* boolean
 * `null(mixed $actual)` - check a given value is *null*
 * `instance(string|lang.Type $expected, mixed $actual)` - check a given value is an instance of the given type.
+* `matches(string $pattern, mixed $actual)` - verify the given value matches a given regular expression.
 * `throws(string|lang.Type $expected, callable $actual)` - verify the given callable raises an exception.
 
 Expected failures

--- a/src/main/php/test/Assert.class.php
+++ b/src/main/php/test/Assert.class.php
@@ -1,7 +1,7 @@
 <?php namespace test;
 
 use lang\Type;
-use test\assert\{Assertable, Equals, Instance};
+use test\assert\{Assertable, Equals, Matches, Instance};
 
 abstract class Assert {
 
@@ -76,6 +76,17 @@ abstract class Assert {
    */
   public static function instance($expected, $actual) {
     (new Assertable($actual))->is(new Instance($expected));
+  }
+
+  /**
+   * Matches shorthand
+   *
+   * @param  string $pattern
+   * @param  callable $actual
+   * @return void
+   */
+  public static function matches($pattern, $actual) {
+    (new Assertable($actual))->is(new Matches($pattern));
   }
 
   /**

--- a/src/main/php/test/Assert.class.php
+++ b/src/main/php/test/Assert.class.php
@@ -82,7 +82,7 @@ abstract class Assert {
    * Matches shorthand
    *
    * @param  string $pattern
-   * @param  callable $actual
+   * @param  mixed $actual
    * @return void
    */
   public static function matches($pattern, $actual) {

--- a/src/main/php/test/assert/Matches.class.php
+++ b/src/main/php/test/assert/Matches.class.php
@@ -1,14 +1,23 @@
 <?php namespace test\assert;
 
+use lang\FormatException;
+
+/** @test test.unittest.MatchesTest */
 class Matches extends Condition {
   protected $pattern;
 
-  public function __construct($pattern) {
+  public function __construct(string $pattern) {
     $this->pattern= $pattern;
   }
 
   public function matches($value) {
-    return preg_match($this->pattern, $value);
+    if (is_string($value) || is_object($value) && method_exists($value, '__toString')) {
+      if (false === ($r= preg_match($this->pattern, $value))) {
+        throw new FormatException(preg_last_error_msg().' in '.$this->pattern);
+      }
+      return $r > 0;
+    }
+    return false;
   }
 
   public function describe($value, $positive) {

--- a/src/main/php/test/assert/Matches.class.php
+++ b/src/main/php/test/assert/Matches.class.php
@@ -13,7 +13,7 @@ class Matches extends Condition {
   public function matches($value) {
     if (is_string($value) || is_object($value) && method_exists($value, '__toString')) {
       if (false === ($r= preg_match($this->pattern, $value))) {
-        throw new FormatException(preg_last_error_msg().' in '.$this->pattern);
+        throw new FormatException('Using '.$this->pattern);
       }
       return $r > 0;
     }

--- a/src/test/php/test/unittest/MatchesTest.class.php
+++ b/src/test/php/test/unittest/MatchesTest.class.php
@@ -33,7 +33,7 @@ class MatchesTest {
     }));
   }
 
-  #[Test, Expect(class: FormatException::class, message: 'Internal error in not.a.regex')]
+  #[Test, Expect(class: FormatException::class, message: 'Using not.a.regex')]
   public function invalid_pattern() {
     (new Matches('not.a.regex'))->matches('Test');
   }

--- a/src/test/php/test/unittest/MatchesTest.class.php
+++ b/src/test/php/test/unittest/MatchesTest.class.php
@@ -1,0 +1,45 @@
+<?php namespace test\unittest;
+
+use lang\FormatException;
+use test\assert\Matches;
+use test\{Assert, Expect, Test, Values};
+
+class MatchesTest {
+
+  #[Test, Values(['/Test/', '/test/i', '/^[tT]es.+/'])]
+  public function matches_test($pattern) {
+    Assert::true((new Matches($pattern))->matches('Test'));
+  }
+
+  #[Test, Values(['/A/', '/test/'])]
+  public function does_not_match($pattern) {
+    Assert::false((new Matches($pattern))->matches('Test'));
+  }
+
+  #[Test, Values([null, false, true, 1, -1.5, [[]]])]
+  public function matches_only_strings($value) {
+    Assert::false((new Matches('/Test/'))->matches($value));
+  }
+
+  #[Test]
+  public function generally_does_not_match_objects() {
+    Assert::false((new Matches('/Test/'))->matches($this));
+  }
+
+  #[Test]
+  public function matches_stringable() {
+    Assert::true((new Matches('/Test/'))->matches(new class() {
+      public function __toString() { return 'Test'; }
+    }));
+  }
+
+  #[Test, Expect(class: FormatException::class, message: 'Internal error in not.a.regex')]
+  public function invalid_pattern() {
+    (new Matches('not.a.regex'))->matches('Test');
+  }
+
+  #[Test]
+  public function shorthand() {
+    Assert::matches('/Test.*/', 'Testing');
+  }
+}


### PR DESCRIPTION
Code that asserts using `preg_match()` does not produce meaningful error messages:

```bash
$ xp -e '\test\Assert::equals(1, preg_match("/ABC/i", "Testing"))'
Uncaught exception: Exception test.AssertionFailed (Failed asserting that 0 is equal to 1)
# ...
```

This pull request solves the problem by adding a *matches* shorthand method which uses the `test.assert.Matches` class.

## Usage

The pattern is included in the assertion error message:

```php
Assert::matches('/^test/i', 'Testing');
// Pass

Assert::matches('/ABC/i', 'Testing');
// Uncaught exception: Exception test.AssertionFailed (Failed asserting that "Testing" matches /ABC/i)
//   at test.Assert::matches((0x6)'/ABC/i', (0x7)'Testing') [line 1 of (command line argument)]
//   at <main>::include((0x17)'(command line argument)') [line 163 of Code.class.php]
//   at xp.runtime.Code::run(array[1]) [line 31 of Evaluate.class.php]
//   at xp.runtime.Evaluate::main(array[1]) [line 389 of class-main.php]
```

## Errors

If `preg_match()` returns an error, an exception is raised. Its stacktrace includes the error message

```php
Assert::matches('not.a.regex', 'Testing');
// Uncaught exception: Exception lang.FormatException (Using not.a.regex)
//   at <main>::preg_match() [line 15 of Matches.class.php] preg_match(): Delimiter must not be alphanumeric, [...]
//   at test.assert.Matches::matches((0x7)'Testing') [line 27 of Assertable.class.php]
//   at test.assert.Assertable::is(test.assert.Matches{}) [line 89 of Assert.class.php]
//   at test.Assert::matches((0xb)'not.a.regex', (0x7)'Testing') [line 1 of (command line argument)]
//   at <main>::include((0x17)'(command line argument)') [line 163 of Code.class.php]
//   at xp.runtime.Code::run(array[1]) [line 31 of Evaluate.class.php]
//   at xp.runtime.Evaluate::main(array[1]) [line 389 of class-main.php]
```